### PR TITLE
made sidebar + header bar sticky

### DIFF
--- a/backend/tests/video.test.ts
+++ b/backend/tests/video.test.ts
@@ -34,13 +34,11 @@ describe("Video Controller - Get Videos", () => {
 //tests create video
 describe("Video Controller - Create Video", () => {
 	it("should create a new video", async () => {
-		const res = await request(app)
-			.post("/api/videos")
-			.send({
-				title: "New Video",
-				description: "New Description",
-				published: true,
-			});
+		const res = await request(app).post("/api/videos").send({
+			title: "New Video",
+			description: "New Description",
+			published: true,
+		});
 
 		expect(res.status).toBe(201);
 		expect(res.body.success).toBe(true);
@@ -66,13 +64,11 @@ describe("Video Controller - Update Video", () => {
 			published: false,
 		});
 
-		const res = await request(app)
-			.put(`/api/videos/${video._id}`)
-			.send({
-				title: "Updated Title",
-				description: "Updated Desc",
-				published: true,
-			});
+		const res = await request(app).put(`/api/videos/${video._id}`).send({
+			title: "Updated Title",
+			description: "Updated Desc",
+			published: true,
+		});
 
 		expect(res.status).toBe(200);
 		expect(res.body.success).toBe(true);

--- a/backend/tests/video.tests.ts
+++ b/backend/tests/video.tests.ts
@@ -33,13 +33,11 @@ describe("Video Controller - Get Videos", () => {
 //tests create video
 describe("Video Controller - Create Video", () => {
 	it("should create a new video", async () => {
-		const res = await request(app)
-			.post("/api/videos")
-			.send({
-				title: "New Video",
-				description: "New Description",
-				published: true,
-			});
+		const res = await request(app).post("/api/videos").send({
+			title: "New Video",
+			description: "New Description",
+			published: true,
+		});
 
 		expect(res.status).toBe(201);
 		expect(res.body.success).toBe(true);
@@ -65,13 +63,11 @@ describe("Video Controller - Update Video", () => {
 			published: false,
 		});
 
-		const res = await request(app)
-			.put(`/api/videos/${video._id}`)
-			.send({
-				title: "Updated Title",
-				description: "Updated Desc",
-				published: true,
-			});
+		const res = await request(app).put(`/api/videos/${video._id}`).send({
+			title: "Updated Title",
+			description: "Updated Desc",
+			published: true,
+		});
 
 		expect(res.status).toBe(200);
 		expect(res.body.success).toBe(true);

--- a/frontend/src/routes/appRoutes.tsx
+++ b/frontend/src/routes/appRoutes.tsx
@@ -23,13 +23,13 @@ function AppRoutes() {
 				<div style={{ width: "100%" }}>
 					<HeaderBar isOpen={isHeaderBarOpen} setIsOpen={setIsHeaderBarOpen} />
 				</div>
-				<div style={{ display: "flex", flex: 1 }}>
-					<div style={{ display: "flex", alignItems: "center" }}>
+					<div style={{ position: "absolute", display: "flex", alignItems: "center", top: "25%" }}>
 						<Sidebar
 							isCollapsed={isCollapsed}
 							setIsCollapsed={setIsCollapsed}
 						/>
 					</div>
+				<div style={{ display: "flex", flex: 1, overflow: "auto", paddingLeft: isCollapsed ? "6rem" : "17rem"}}>
 					<Routes>
 						<Route path="/" element={<Home />} />
 						<Route path="/catalog" element={<Catalog />} />

--- a/frontend/src/routes/appRoutes.tsx
+++ b/frontend/src/routes/appRoutes.tsx
@@ -23,13 +23,24 @@ function AppRoutes() {
 				<div style={{ width: "100%" }}>
 					<HeaderBar isOpen={isHeaderBarOpen} setIsOpen={setIsHeaderBarOpen} />
 				</div>
-					<div style={{ position: "absolute", display: "flex", alignItems: "center", top: "25%" }}>
-						<Sidebar
-							isCollapsed={isCollapsed}
-							setIsCollapsed={setIsCollapsed}
-						/>
-					</div>
-				<div style={{ display: "flex", flex: 1, overflow: "auto", paddingLeft: isCollapsed ? "6rem" : "17rem"}}>
+				<div
+					style={{
+						position: "absolute",
+						display: "flex",
+						alignItems: "center",
+						top: "25%",
+					}}
+				>
+					<Sidebar isCollapsed={isCollapsed} setIsCollapsed={setIsCollapsed} />
+				</div>
+				<div
+					style={{
+						display: "flex",
+						flex: 1,
+						overflow: "auto",
+						paddingLeft: isCollapsed ? "6rem" : "17rem",
+					}}
+				>
 					<Routes>
 						<Route path="/" element={<Home />} />
 						<Route path="/catalog" element={<Catalog />} />


### PR DESCRIPTION
As said in title. Changed some ordering of components in `appRoutes.tsx`: moved sidebar outside of the `<div>` for the home page, and added some conditional padding in the home page's `<div>` to ensure the sidebar doesn't overlap the content. 

# Remaining TODOs: 

- @kohrachel fix sidebar behavior on some mobile/tablet screens (add breakpoints for collapsing) 
- fix home page behavior -- background color doesn't fill the whole screen (see the second preview with the narrower screen, the gray stops before the end of the page). 
    - Note: setting `height: min-content` on the parent element solves this but broke the centering of the sidebar for me

# Some previews below: 

## Full-screen (desktop)
![demo](https://github.com/user-attachments/assets/d23d4e5d-7743-47da-a213-fb92a6ef0212)

## Narrow-screen (desktop) 
![demo2](https://github.com/user-attachments/assets/9d5ce9d4-309a-44b9-8a31-6595583e37d7)