### PR TITLE
Updated Admin Tools on Sidebar

### DIFF
--- a/frontend/src/components/Sidebar/sidebar.tsx
+++ b/frontend/src/components/Sidebar/sidebar.tsx
@@ -127,7 +127,7 @@ export function Sidebar({
 			<SidebarItems
 				isCollapsed={isCollapsed}
 				isLoggedIn={isLoggedIn}
-				isAdmin={true}
+				isAdmin={userInfo.isAdmin}
 				setIsLoggedIn={setIsLoggedIn}
 				cartItemCount={cartItemCount}
 			/>
@@ -190,11 +190,6 @@ export function SidebarItems({
 	setIsLoggedIn,
 	cartItemCount,
 }: SidebarItemsProps) {
-	// Helper function for active tab highlighting
-	// const handleItemClick = (item: string) => {
-	// 	setActiveItem(item);
-	// };
-
 	const handleLogOut = async () => {
 		try {
 			await authService.logout();

--- a/frontend/src/components/Sidebar/sidebar.tsx
+++ b/frontend/src/components/Sidebar/sidebar.tsx
@@ -24,7 +24,7 @@ export const userInfo = {
 	role: localStorage.user ? localStorage.user.role : "No role",
 	isLoggedIn: false,
 	isAdmin: localStorage.user
-		? localStorage.user.role === "Admin"
+		? localStorage.user.role === "staff"
 			? true
 			: false
 		: false,

--- a/frontend/src/components/Sidebar/sidebar.tsx
+++ b/frontend/src/components/Sidebar/sidebar.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import "./sidebar.css";
 import {
 	House,
+	KeyRound,
 	LayoutDashboard,
 	BookOpen,
 	Mic,
@@ -15,12 +16,18 @@ import {
 } from "lucide-react";
 
 import authService from "../../services/authService";
+import { log } from "console";
 
 // User information
 export const userInfo = {
 	name: "First L.",
 	role: localStorage.user ? localStorage.user.role : "No role",
 	isLoggedIn: false,
+	isAdmin: localStorage.user
+		? localStorage.user.role === "Admin"
+			? true
+			: false
+		: false,
 };
 
 // All sidebar entries
@@ -62,6 +69,13 @@ export const items = [
 		href: "mailto:info@fostersource.org",
 	},
 ];
+
+// Admin information for conditional rendering
+export const admin = {
+	icon: <KeyRound />,
+	description: "Admin Tools",
+	href: "/admin",
+};
 
 // Logout information for conditional rendering
 export const logout = {
@@ -113,6 +127,7 @@ export function Sidebar({
 			<SidebarItems
 				isCollapsed={isCollapsed}
 				isLoggedIn={isLoggedIn}
+				isAdmin={true}
 				setIsLoggedIn={setIsLoggedIn}
 				cartItemCount={cartItemCount}
 			/>
@@ -161,6 +176,7 @@ export function Profile({ isCollapsed, isLoggedIn, name, role }: ProfileProps) {
 
 interface SidebarItemsProps {
 	isLoggedIn: boolean;
+	isAdmin: boolean;
 	isCollapsed: boolean;
 	setIsLoggedIn: Dispatch<SetStateAction<boolean>>;
 	cartItemCount: number;
@@ -170,6 +186,7 @@ interface SidebarItemsProps {
 export function SidebarItems({
 	isCollapsed,
 	isLoggedIn,
+	isAdmin,
 	setIsLoggedIn,
 	cartItemCount,
 }: SidebarItemsProps) {
@@ -179,7 +196,6 @@ export function SidebarItems({
 	// };
 
 	const handleLogOut = async () => {
-		// handleItemClick("logout");
 		try {
 			await authService.logout();
 		} catch (err: any) {
@@ -215,15 +231,25 @@ export function SidebarItems({
 		);
 	});
 
-	const active = activeItem === logout.description ? "active" : "";
+	const adminActive = activeItem === admin.href ? "active" : "";
+	const logoutActive = activeItem === logout.href ? "active" : "";
 	const iconDescMargin = !isCollapsed ? "mr-4" : "";
 
 	return (
 		<ul className="menu mb-4">
+			{isAdmin && (
+				<li
+					className={`${adminActive}`}
+					onClick={() => setActiveItem(window.location.pathname)}
+				>
+					<div className={`${iconDescMargin}`}>{admin.icon}</div>
+					<Link to={admin.href}>{!isCollapsed && admin.description}</Link>
+				</li>
+			)}
 			{sidebarItems}
 			{isLoggedIn && (
 				<div className="logout">
-					<li className={`${active}`} onClick={() => handleLogOut()}>
+					<li className={`${logoutActive}`} onClick={() => handleLogOut()}>
 						<div className={`${iconDescMargin}`}>{logout.icon}</div>
 						<Link to={logout.href}>{!isCollapsed && logout.description}</Link>
 					</li>


### PR DESCRIPTION
Conditionally render Admin Tools option on sidebar if the user has role "staff". Button redirects to `/admin`.

Preview with the tab highlighted: 
<img width="259" alt="Sidebar with highlighted Admin Tools" src="https://github.com/user-attachments/assets/77826f61-551b-4ca9-888b-aeebf74b3fe1" />

Preview without the tab visible:
<img width="259" alt="image" src="https://github.com/user-attachments/assets/8b4604cd-e3ea-4421-ae32-22a2eff5dba1" />
