### PR TITLE
Added Creating Workshop Flow

### DIFF
--- a/backend/routes/userRoutes.ts
+++ b/backend/routes/userRoutes.ts
@@ -27,7 +27,9 @@ router.delete("/:id", deleteUser);
 // PUT Registers a user for a bunch of classes
 router.post("/register", register);
 
+// @ts-ignore
 router.get("/is-admin", verifyFirebaseAuth, checkAdmin); // Protect the route
 
 
+// @ts-ignore
 export default router;

--- a/frontend/src/pages/Admin/ComponentPage/WorkshopCard.tsx
+++ b/frontend/src/pages/Admin/ComponentPage/WorkshopCard.tsx
@@ -2,7 +2,7 @@ import { Dispatch, SetStateAction } from "react";
 import Dropdown from "../../../components/dropdown-select";
 import {Video, Calendar, Wifi} from "lucide-react";
 import DisplayBar from "./DisplayBar";
-import { WebinarType } from "../../../shared/types/webinar";
+import { WebinarType } from "../../../shared/types/Webinar";
 
 interface WorkshopProps {
   webinar?: WebinarType

--- a/frontend/src/pages/Admin/WorkshopCreation/InPerson.tsx
+++ b/frontend/src/pages/Admin/WorkshopCreation/InPerson.tsx
@@ -1,0 +1,27 @@
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
+import {WebinarType} from "../../../shared/types/Webinar";
+
+interface InPersonComponentProps {
+    inPersonData:{
+        startTime: Date | null,
+        duration: number,
+        location: string
+    };
+    setInPersonData: Dispatch<SetStateAction<any>>;
+}
+export default function InPersonComponent({inPersonData, setInPersonData}:InPersonComponentProps) {
+    const handleChange = (e:any) => {
+        const { name, value } = e.target;
+        setInPersonData({ ...inPersonData, [name]: value });
+    };
+    return (
+        <div className="mt-6 flex justify-left gap-2">
+            <div>
+                <label className="text-sm font-medium block">Start Time</label>
+                <input name="title" value={inPersonData.startTime?inPersonData.startTime.toString() : ""} onChange={handleChange} className="mt-1 w-full p-2 border rounded" placeholder="" required />
+            </div>
+            <div>
+                <label className="text-sm font-medium block">Location</label>
+                <input name="title" value={inPersonData.location} onChange={handleChange} className="mt-1 w-full p-2 border rounded" placeholder="" required />
+            </div>
+        </div>)}

--- a/frontend/src/pages/Admin/WorkshopCreation/Modal.tsx
+++ b/frontend/src/pages/Admin/WorkshopCreation/Modal.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+
+type ModalProps = {
+    isOpen: boolean;
+    onClose: () => void;
+    title?: string;
+    children: React.ReactNode;
+};
+
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
+    if (!isOpen) return null;
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+            <div className="bg-white rounded-lg shadow-lg max-w-md w-full p-6 relative">
+                {/* Close Button (X) */}
+                <button
+                    onClick={onClose}
+                    className="absolute top-3 right-3 text-gray-600 hover:text-gray-900"
+                >
+                    ✖
+                </button>
+
+                {/* Title */}
+                {title && <h2 className="text-xl font-semibold mb-4">{title}</h2>}
+
+                {/* Content */}
+                <div>{children}</div>
+
+                {/* Footer */}
+                <div className="mt-4 flex justify-end">
+                    <button
+                        onClick={onClose}
+                        className="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400"
+                    >
+                        Close
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default Modal;

--- a/frontend/src/pages/Admin/WorkshopCreation/OnDemand.tsx
+++ b/frontend/src/pages/Admin/WorkshopCreation/OnDemand.tsx
@@ -1,0 +1,20 @@
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
+
+interface OnDemandComponentProps {
+    onDemandData:{
+        embeddingLink: string
+    };
+    setOnDemandData: Dispatch<SetStateAction<any>>;
+}
+export default function OnDemandComponent({onDemandData, setOnDemandData}:OnDemandComponentProps) {
+    const handleChange = (e:any) => {
+        const { name, value } = e.target;
+        setOnDemandData({ ...onDemandData, [name]: value });
+    };
+    return (
+        <div>
+            <label className="text-sm font-medium block">Embedding Link</label>
+            <input name="title" value={onDemandData.embeddingLink} onChange={handleChange} className="mt-1 w-full p-2 border rounded" placeholder="" required />
+        </div>
+    )
+}

--- a/frontend/src/pages/Admin/WorkshopCreation/Webinar.tsx
+++ b/frontend/src/pages/Admin/WorkshopCreation/Webinar.tsx
@@ -1,0 +1,16 @@
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
+import {WebinarType} from "../../../shared/types/Webinar";
+
+interface WebinarComponentProps {
+    webinarData:WebinarType;
+    setWebinarData: Dispatch<SetStateAction<any>>;
+}
+export default function WebinarComponent(
+    {webinarData, setWebinarData}:WebinarComponentProps
+) {
+    return (
+        <div className="mt-6 flex justify-left gap-2">
+            <button type="submit" className="px-4 py-2 bg-purple-800 text-white rounded">Create New Webinar</button>
+            <button type="button" className="px-4 py-2 border border-purple-800 text-purple-800 rounded">Use Existing Webinar</button>
+        </div>)
+}

--- a/frontend/src/pages/Admin/WorkshopCreation/Webinar.tsx
+++ b/frontend/src/pages/Admin/WorkshopCreation/Webinar.tsx
@@ -4,13 +4,15 @@ import {WebinarType} from "../../../shared/types/Webinar";
 interface WebinarComponentProps {
     webinarData:WebinarType;
     setWebinarData: Dispatch<SetStateAction<any>>;
+    openModal:string|null;
+    setOpenModal: Dispatch<SetStateAction<any>>;
 }
 export default function WebinarComponent(
-    {webinarData, setWebinarData}:WebinarComponentProps
+    {webinarData, setWebinarData, openModal, setOpenModal}:WebinarComponentProps
 ) {
     return (
         <div className="mt-6 flex justify-left gap-2">
-            <button type="submit" className="px-4 py-2 bg-purple-800 text-white rounded">Create New Webinar</button>
-            <button type="button" className="px-4 py-2 border border-purple-800 text-purple-800 rounded">Use Existing Webinar</button>
+            <button type="submit" className="px-4 py-2 bg-purple-800 text-white rounded" onClick={() => setOpenModal("New")}>Create New Webinar</button>
+            <button type="button" className="px-4 py-2 border border-purple-800 text-purple-800 rounded" onClick={() => setOpenModal("Existing")}>Use Existing Webinar</button>
         </div>)
 }

--- a/frontend/src/pages/Admin/WorkshopCreation/WorkshopCreation.tsx
+++ b/frontend/src/pages/Admin/WorkshopCreation/WorkshopCreation.tsx
@@ -1,0 +1,198 @@
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
+import WebinarComponent from "./Webinar";
+import InPersonComponent from "./InPerson";
+import OnDemandComponent from "./OnDemand";
+import Modal from "./Modal";
+
+
+interface WorkshopCreationProps {
+    workshopName: string;
+}
+export default function WorkshopCreation({ workshopName}:WorkshopCreationProps) {
+    const [formData, setFormData] = useState({
+        title: "",
+        summary: "",
+        type: "webinar",
+        audioInstructions: "",
+        markAttendance: false,
+        requireAttendance: false,
+        gradeUser: false,
+        emailUnattended: false,
+        hideAfter: false,
+        minTime: 0,
+    });
+
+    const [webinarData, setWebinarData] = useState({
+        serviceType: "",
+        meetingID: "string",
+        startTime: new Date(),
+        duration: 0,
+        authParticipants: false,
+        autoRecord: false,
+        enablePractice: false,
+    })
+
+    const [inPersonData, setInPersonData] = useState({
+        startTime: null,
+        duration: 0,
+        location: ""
+    })
+
+    const [onDemandData, setOnDemandData] = useState({
+        embeddingLink: ""
+    })
+
+    const [isModalOpen, setIsModalOpen] = useState(false);
+
+    const openModal = () => {
+        setIsModalOpen(true);
+    };
+
+    const closeModal = () => {
+        setIsModalOpen(false);
+    };
+
+    const handleChange = (e:any) => {
+        const { name, value } = e.target;
+        setFormData({ ...formData, [name]: value });
+    };
+
+    const handleSubmit = (event:any) => {
+        event.preventDefault();
+        console.log("Form submitted:", formData);
+    };
+
+    return (
+        <div>
+            <form onSubmit={handleSubmit} className="p-6 w-full ">
+                <h2 className="text-xl font-semibold flex items-center gap-2">
+                    {workshopName}
+                </h2>
+                <div className="mt-4">
+                    <label className="text-sm font-medium block">Title</label>
+                    <input name="title" value={formData.title} onChange={handleChange} className="mt-1 w-full p-2 border rounded" placeholder="" required />
+                </div>
+                <div className="mt-4">
+                    <label className="text-sm font-medium block">Summary</label>
+                    <textarea name="summary" value={formData.summary} onChange={handleChange} className="mt-1 w-full p-2 border rounded" required />
+                </div>
+                <div className="mt-4">
+                    <label className="text-sm font-medium block">Type</label>
+                    <div className="mt-2 flex gap-4">
+                        <label className="flex items-center gap-2">
+                            <input type="radio" name="type" value="webinar" checked={formData.type === "webinar"} onChange={handleChange} required /> Webinar
+                        </label>
+                        <label className="flex items-center gap-2">
+                            <input type="radio" name="type" value="in-person" onChange={handleChange} /> In-Person
+                        </label>
+                        <label className="flex items-center gap-2">
+                            <input type="radio" name="type" value="on-demand" onChange={handleChange} /> On-Demand
+                        </label>
+                    </div>
+                </div>
+                <div className="py-5">
+                    {formData.type === "webinar" ? (
+                        <WebinarComponent setWebinarData={setWebinarData} webinarData={webinarData}/>
+                    ) : formData.type === "in-person" ? (
+                        <InPersonComponent  inPersonData={inPersonData} setInPersonData={setInPersonData}/>
+                    ) : (
+                        <OnDemandComponent  onDemandData={onDemandData} setOnDemandData={setOnDemandData}/>
+                    )}
+                </div>
+
+                <div className="grid grid-cols-2 gap-6 py-5">
+                    {/* Left Column */}
+                    <div className="space-y-3">
+                        <label className="flex items-center gap-2 font-medium">
+                            <input
+                                type="checkbox"
+                                className="w-5 h-5"
+                                name="markAttendance"
+                                checked={formData.markAttendance}
+                                onChange={(e) => {
+                                    const checked = e.target.checked;
+                                    setFormData((prev) => ({
+                                        ...prev,
+                                        markAttendance: checked,
+                                        requireAttendance: checked ? prev.requireAttendance : false, // Reset if unchecked
+                                        minTime: checked ? prev.minTime : 0, // Reset minTime
+                                    }));
+                                }}
+                            />
+                            Mark User Attendance
+                        </label>
+
+                        <div className={`pl-6 space-y-2 ${!formData.markAttendance ? "opacity-50 pointer-events-none" : ""}`}>
+                            <label className="flex items-center gap-2 text-gray-500">
+                                <input
+                                    type="checkbox"
+                                    className="w-4 h-4"
+                                    name="requireAttendance"
+                                    checked={formData.requireAttendance}
+                                    onChange={(e) => setFormData((prev) => ({ ...prev, requireAttendance: e.target.checked }))}
+                                />
+                                Attendance required for completion
+                            </label>
+                            <div>
+                                <label className="block text-gray-500 text-sm">Minimum Time (mins)</label>
+                                <input
+                                    type="number"
+                                    className="w-16 border rounded px-2 py-1 text-gray-500"
+                                    min="0"
+                                    value={formData.minTime}
+                                    onChange={(e) => setFormData((prev) => ({ ...prev, minTime: parseInt(e.target.value) }))}
+                                />
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Right Column */}
+                    <div className="space-y-3">
+                        <label className="flex items-center gap-2 font-medium">
+                            <input
+                                type="checkbox"
+                                className="w-5 h-5"
+                                name="gradeUser"
+                                checked={formData.gradeUser}
+                                onChange={(e) => setFormData((prev) => ({ ...prev, gradeUser: e.target.checked }))}
+                            />
+                            Grade User
+                        </label>
+
+                        <label className="flex items-center gap-2 font-medium">
+                            <input
+                                type="checkbox"
+                                className="w-5 h-5"
+                                name="emailUnattended"
+                                checked={formData.emailUnattended}
+                                onChange={(e) => setFormData((prev) => ({ ...prev, emailUnattended: e.target.checked }))}
+                            />
+                            Email Registrants Who Do Not Attend
+                        </label>
+
+                        <label className="flex items-center gap-2 font-medium">
+                            <input
+                                type="checkbox"
+                                className="w-5 h-5"
+                                name="hideAfter"
+                                checked={formData.hideAfter}
+                                onChange={(e) => setFormData((prev) => ({ ...prev, hideAfter: e.target.checked }))}
+                            />
+                            Hide Component after Live Event
+                        </label>
+                    </div>
+                </div>
+
+                <div className="mt-4">
+                    <label className="text-sm font-medium block">Audio Instructions</label>
+                    <textarea name="audioInstructions" value={formData.audioInstructions} onChange={handleChange} className="mt-1 w-full p-2 border rounded" required />
+                </div>
+                <div className="mt-6 flex justify-end gap-2">
+                    <button type="submit" className="px-4 py-2 bg-purple-800 text-white rounded">Save and Exit</button>
+                    <button type="button" className="px-4 py-2 border border-purple-800 text-purple-800 rounded">Exit</button>
+                </div>
+            </form>
+        </div>
+    );
+}
+

--- a/frontend/src/pages/Admin/WorkshopCreation/WorkshopCreation.tsx
+++ b/frontend/src/pages/Admin/WorkshopCreation/WorkshopCreation.tsx
@@ -42,15 +42,9 @@ export default function WorkshopCreation({ workshopName}:WorkshopCreationProps) 
         embeddingLink: ""
     })
 
-    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [openModal, setOpenModal] = useState<"New" | "Existing" | null>(null);
 
-    const openModal = () => {
-        setIsModalOpen(true);
-    };
 
-    const closeModal = () => {
-        setIsModalOpen(false);
-    };
 
     const handleChange = (e:any) => {
         const { name, value } = e.target;
@@ -92,7 +86,7 @@ export default function WorkshopCreation({ workshopName}:WorkshopCreationProps) 
                 </div>
                 <div className="py-5">
                     {formData.type === "webinar" ? (
-                        <WebinarComponent setWebinarData={setWebinarData} webinarData={webinarData}/>
+                        <WebinarComponent setWebinarData={setWebinarData} webinarData={webinarData} openModal={openModal} setOpenModal={setOpenModal}/>
                     ) : formData.type === "in-person" ? (
                         <InPersonComponent  inPersonData={inPersonData} setInPersonData={setInPersonData}/>
                     ) : (
@@ -192,6 +186,16 @@ export default function WorkshopCreation({ workshopName}:WorkshopCreationProps) 
                     <button type="button" className="px-4 py-2 border border-purple-800 text-purple-800 rounded">Exit</button>
                 </div>
             </form>
+
+            {/* First Modal */}
+            <Modal isOpen={openModal === "New"} onClose={() => setOpenModal(null)} title="Create New Webinar">
+                <p>This is the placeholder for adding a new webinar (once we get zoom).</p>
+            </Modal>
+
+            {/* Second Modal */}
+            <Modal isOpen={openModal === "Existing"} onClose={() => setOpenModal(null)} title="Add Existing Webinar">
+                <p>This is placeholder for finding existing webinars.</p>
+            </Modal>
         </div>
     );
 }

--- a/frontend/src/routes/appRoutes.tsx
+++ b/frontend/src/routes/appRoutes.tsx
@@ -18,12 +18,13 @@ import ResetPasswordForm from "../pages/UserAuth/resetPasswordForm";
 import authService from "../services/authService";
 import CoursePage from "../pages/courseDetailPage/courseDetailsPage";
 import DiscountPage from "../pages/Admin/DiscountPage/Discount";
-import ProductPage from "../pages/Admin/ProductPage/ProductPage";
+// import ProductPage from "../pages/Admin/ProductPage/ProductPage";
 import Dashboard from "../pages/Dashboard/dashboard";
 import Cart from "../pages/CartPage/cart";
 import Pricing from "../pages/Admin/Products/Pricing"
 import ComponentPage from "../pages/Admin/ComponentPage/Component";
-import AdminPage from "../pages/Admin/AdminPage";
+import WorkshopCreation from "../pages/Admin/WorkshopCreation/WorkshopCreation";
+// import AdminPage from "../pages/Admin/AdminPage";
 
 function AppRoutes() {
 	const [isHeaderBarOpen, setIsHeaderBarOpen] = useState(false);
@@ -120,11 +121,12 @@ function AppRoutes() {
 							path="/reset-password/:token"
 							element={<ResetPasswordForm />}
 						/>
-						<Route path="/admin" element={<AdminPage />} />
+						{/*<Route path="/admin" element={<AdminPage />} />*/}
 						<Route path="/admin/discounts" element={<DiscountPage />} />
 						<Route path="/admin/products/pricing" element={<Pricing />} />
 						<Route path="/admin/components" element = {<ComponentPage workshop={undefined} survey={undefined} certificate={undefined} />}/>
-						<Route path="/admin/products" element={<ProductPage />} />
+						{/*<Route path="/admin/products" element={<ProductPage />} />*/}
+						<Route path="/admin/create-workshop" element={<WorkshopCreation  workshopName={`Workshop | The Inclusive Family Support Model`}/>} />
 						<Route
 							path="/courseDetails"
 							element={<CoursePage setCartItemCount={setCartItemCount} />}


### PR DESCRIPTION
Added the options for creating a workshop, with three options. 

It takes in the title of the course and then has fields for a workshop title and summary. 

Webinar: 
<img width="861" alt="Screenshot 2025-02-24 at 7 04 03 PM" src="https://github.com/user-attachments/assets/1dedff50-2239-47ee-ad50-263713f22f07" />
Opens up a modal for either creating a new webinar or choosing from an existing one. 

In Person:
<img width="883" alt="image" src="https://github.com/user-attachments/assets/bc81ec2c-82a3-4e97-9912-fe6601fb4068" />
Set up a time and location. 

On Demand:
<img width="839" alt="image" src="https://github.com/user-attachments/assets/3e3a45c7-8060-4494-a301-9d590c90f73f" />
Add a link for the embedding

In addition, the creation also allows for additional information about audio information and other options. The require attendance for completion option is only available for the track attendance option. 

Right now, the Save and Exit and the Exit buttons don't do anything right now because we cannot save stuff yet.  
