### PR TITLE
Zoom Integration Fallback

### DIFF
--- a/frontend/src/pages/Admin/WorkshopCreation/Webinar.tsx
+++ b/frontend/src/pages/Admin/WorkshopCreation/Webinar.tsx
@@ -2,17 +2,25 @@ import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
 import {WebinarType} from "../../../shared/types/Webinar";
 
 interface WebinarComponentProps {
-    webinarData:WebinarType;
+    webinarData: { meetingID: string,
+        meetingPassword: string };
     setWebinarData: Dispatch<SetStateAction<any>>;
-    openModal:string|null;
-    setOpenModal: Dispatch<SetStateAction<any>>;
 }
 export default function WebinarComponent(
-    {webinarData, setWebinarData, openModal, setOpenModal}:WebinarComponentProps
+    {webinarData, setWebinarData}:WebinarComponentProps
 ) {
+    const handleChange = (e:any) => {
+        const { name, value } = e.target;
+        setWebinarData({ ...webinarData, [name]: value });
+    };
     return (
         <div className="mt-6 flex justify-left gap-2">
-            <button type="submit" className="px-4 py-2 bg-purple-800 text-white rounded" onClick={() => setOpenModal("New")}>Create New Webinar</button>
-            <button type="button" className="px-4 py-2 border border-purple-800 text-purple-800 rounded" onClick={() => setOpenModal("Existing")}>Use Existing Webinar</button>
+            {/*<button type="submit" className="px-4 py-2 bg-purple-800 text-white rounded" onClick={() => setOpenModal("New")}>Create New Webinar</button>*/}
+            {/*<button type="button" className="px-4 py-2 border border-purple-800 text-purple-800 rounded" onClick={() => setOpenModal("Existing")}>Use Existing Webinar</button>*/}
+
+            <label className="text-sm font-medium block">Meeting ID</label>
+            <input name="title" value={webinarData.meetingID} onChange={handleChange} className="mt-1 w-full p-2 border rounded" placeholder="" required />
+            <label className="text-sm font-medium block">Meeting Password</label>
+            <input name="title" value={webinarData.meetingPassword} onChange={handleChange} className="mt-1 w-full p-2 border rounded" placeholder="" required />
         </div>)
 }

--- a/frontend/src/pages/Admin/WorkshopCreation/WorkshopCreation.tsx
+++ b/frontend/src/pages/Admin/WorkshopCreation/WorkshopCreation.tsx
@@ -24,13 +24,8 @@ export default function WorkshopCreation({
 	});
 
 	const [webinarData, setWebinarData] = useState({
-		serviceType: "",
-		meetingID: "string",
-		startTime: new Date(),
-		duration: 0,
-		authParticipants: false,
-		autoRecord: false,
-		enablePractice: false,
+		meetingID: "",
+		meetingPassword: ""
 	});
 
 	const [inPersonData, setInPersonData] = useState({
@@ -42,8 +37,6 @@ export default function WorkshopCreation({
 	const [onDemandData, setOnDemandData] = useState({
 		embeddingLink: "",
 	});
-
-	const [openModal, setOpenModal] = useState<"New" | "Existing" | null>(null);
 
 	const handleChange = (e: any) => {
 		const { name, value } = e.target;
@@ -121,8 +114,6 @@ export default function WorkshopCreation({
 						<WebinarComponent
 							setWebinarData={setWebinarData}
 							webinarData={webinarData}
-							openModal={openModal}
-							setOpenModal={setOpenModal}
 						/>
 					) : formData.type === "in-person" ? (
 						<InPersonComponent
@@ -276,26 +267,6 @@ export default function WorkshopCreation({
 					</button>
 				</div>
 			</form>
-
-			{/* First Modal */}
-			<Modal
-				isOpen={openModal === "New"}
-				onClose={() => setOpenModal(null)}
-				title="Create New Webinar"
-			>
-				<p>
-					This is the placeholder for adding a new webinar (once we get zoom).
-				</p>
-			</Modal>
-
-			{/* Second Modal */}
-			<Modal
-				isOpen={openModal === "Existing"}
-				onClose={() => setOpenModal(null)}
-				title="Add Existing Webinar"
-			>
-				<p>This is placeholder for finding existing webinars.</p>
-			</Modal>
 		</div>
 	);
 }


### PR DESCRIPTION
# Fallback Input for Zoom Integration 

Since Zoom is annoying, here's a fallback with the meeting id and meeting password as inputs. 

<img width="1171" alt="Screenshot 2025-04-07 at 3 40 48 PM" src="https://github.com/user-attachments/assets/80ed1480-45a6-4c3f-abc5-f574a74f36ca" />

It can just sit here unmerged for a bit (it's also not connected to the backend since we'd have to change the models to accommodate and I didn't want to mess with that stuff yet in case, but I wanted to get this in in case we needed it. 