### PR TITLE
feat: Survey system overhaul; per-course surveys, versioning, and statistics

### DIFF
--- a/backend/controllers/surveyController.ts
+++ b/backend/controllers/surveyController.ts
@@ -1,143 +1,303 @@
 import { Request, Response } from "express";
 import Survey, { ISurvey } from "../models/surveyModel";
+import Course from "../models/courseModel";
+import SurveyResponse from "../models/surveyResponseModel";
 
-// @desc    Get the single survey
-// @route   GET /api/surveys
-// @access  Public
-export const getSurvey = async (req: Request, res: Response): Promise<void> => {
+// @desc Get all active surveys
+// @route GET /api/surveys?courseId=
+export const getSurveys = async(req: Request, res: Response): Promise<void> => {
 	try {
-		// Use `findOneAndUpdate` to find the survey and create one if it doesn't exist
-		const survey = await Survey.findOneAndUpdate(
-			{}, // Find the first document (survey)
-			{ $setOnInsert: { questions: [] } }, // If no document is found, insert a new one with empty questions
-			{ new: true, upsert: true } // Return the updated/new document, and if not found, create it
-		).populate({
+		const { courseId } = req.query;
+		const filter: any = {isActive: true};
+		if (courseId) filter.courseIds = courseId;
+
+		const surveys = await Survey.find(filter).populate({
 			path: "questions",
 			model: "Question",
 		});
 
-		res.status(200).json(survey);
+		res.status(200).json({success: true, data: surveys});
 	} catch (error) {
 		if (error instanceof Error) {
-			res.status(500).json({ message: error.message });
+			res.status(500).json({success: false, message: error.message});
 		} else {
-			res.status(500).json({ message: "An unknown error occurred" });
+			res.status(500).json({success: false, message: "Internal service error."});
 		}
 	}
 };
 
-// @desc    Create a new survey (only if it doesn't already exist)
-// @route   POST /api/surveys
-// @access  Public
-export const createSurvey = async (
-	req: Request,
-	res: Response
-): Promise<void> => {
+// @desc Get survey by ID
+// @route GET /api/surveys/:id
+export const getSurveyById = async(req: Request, res: Response): Promise<void> => {
 	try {
-		// Check if a survey already exists
-		const existingSurvey = await Survey.findOne();
+		const survey = await Survey.findById(req.params.id).populate({
+			path: "questions",
+			model: "Question",
+		});
 
-		if (existingSurvey) {
-			res.status(200).json({
-				survey: existingSurvey,
-				message: "Survey already exists. You can update it instead.",
-			});
+		if (!survey) {
+			res.status(404).json({success: false, message: "Survey not found."});
 			return;
 		}
+		
+		res.status(200).json({survey});
+	} catch (error) {
+		if (error instanceof Error) {
+			res.status(500).json({success: false, message: error.message});
+		} else {
+			res.status(500).json({success: false, message: "Internal service error."});
+		}
+	}
+};
 
-		const { questions } = req.body;
+// @desc Create new survey
+// @route POST /api/surveys
+export const createSurvey = async(req: Request, res: Response): Promise<void> => {
+	try {
+		const { name, questions, courseIds } = req.body;
 
-		if (!questions) {
-			res.status(400).json({ message: "Questions are required" });
+		if (!name || !questions) {
+			res.status(400).json({success: false, message: "Name and questions are required."});
 			return;
 		}
-
-		// Create a new survey
+		
 		const survey = new Survey({
+			name,
 			questions,
+			courseIds: courseIds || [],
+			version: 1,
+			isActive: true,
 		});
 		await survey.save();
 
-		res.status(201).json({
-			survey,
-			message: "Survey created successfully",
-		});
+		// update each linked course's surveyId
+		if (courseIds && courseIds.length > 0) {
+			await Course.updateMany(
+				{ _id: { $in: courseIds } },
+				{ surveyId: survey._id }
+			);
+		}
+
+		res.status(201).json({success: true, data: survey});
 	} catch (error) {
 		if (error instanceof Error) {
-			res.status(500).json({ message: error.message });
+			res.status(500).json({success: false, message: error.message});
 		} else {
-			res.status(500).json({ message: "An unknown error occurred" });
+			res.status(500).json({success: false, message: "Internal service error."});
 		}
 	}
 };
 
-// @desc    Update the existing survey
-// @route   PUT /api/surveys
-// @access  Public
-export const updateSurvey = async (
-	req: Request,
-	res: Response
-): Promise<void> => {
+// @desc Update survey (copy-on-write versioning if responses exist)
+// @route PUT /api/surveys/:id
+// @body { name?, questions?, courseIdsToUpdate?: string[] }
+//
+// courseIdsToUpdate controls which courses get the new version.
+// Courses not listed keep pointing to the old version.
+// If omitted, All linked courses will get the new version.
+export const updateSurvey = async(req: Request, res: Response) : Promise<void> => {
 	try {
-		const { questions } = req.body;
-
-		console.log(questions);
-
-		// Find the single existing survey (since there is only one survey)
-		const survey = await Survey.findOne();
+		const {name, questions, courseIdsToUpdate} = req.body;
+		const survey = await Survey.findById(req.params.id);
 
 		if (!survey) {
-			res.status(404).json({ message: "Survey not found" });
+			res.status(404).json({success: false, message: "Survey not found."});
 			return;
 		}
 
-		// Update the survey with new questions
-		survey.questions = questions;
+		// Check if there are existing responses for this survey
+		const responseCount = await SurveyResponse.countDocuments({surveyId: survey._id});
+
+		if (responseCount === 0) {
+			// No responses, safe to update in place
+			if (name) survey.name = name;
+			if (questions) survey.questions = questions;
+
+			await survey.save();
+
+			const populated = await survey.populate({ path: "questions", model: "Question" });
+			res.status(200).json({success: true, data: populated});
+			return;
+		}
+
+		const coursesToUpdate = courseIdsToUpdate || survey.courseIds.map(id => id.toString());
+
+		const coursesStaying = survey.courseIds.map(id => id.toString()).filter(id => !coursesToUpdate.includes(id));
+
+		const newSurvey = new Survey({
+			name: name || survey.name,
+			questions: questions || survey.questions,
+			courseIds: coursesToUpdate,
+			version: survey.version + 1,
+			parentSurveyId: survey._id,
+			isActive: true,
+		});
+		await newSurvey.save();
+
+		// Deactive old survey if no courses remain, otherwise trim its courseIds
+		if (coursesStaying.length === 0) {
+			survey.isActive = false;
+			survey.courseIds = [];
+		} else {
+			survey.courseIds = coursesStaying as any;
+		}
 		await survey.save();
-		console.log("survey", survey);
 
-		res.status(200).json(survey);
+		// Point updating courses to new survey
+		await Course.updateMany(
+			{ _id: { $in: coursesToUpdate } },
+			{ surveyId: newSurvey._id }
+		);
+
+		const populated = await newSurvey.populate({ path: "questions", model: "Question" });
+		res.status(200).json({success: true, data: populated});
 	} catch (error) {
 		if (error instanceof Error) {
-			console.error(error);
-			res.status(500).json({ message: error.message });
+			res.status(500).json({success: false, message: error.message});
 		} else {
-			res.status(500).json({ message: "An unknown error occurred" });
+			res.status(500).json({success: false, message: "Internal service error."});
 		}
 	}
 };
 
-// @desc    Delete the survey
-// @route   DELETE /api/surveys
-// @access  Public
-export const deleteSurvey = async (
-	req: Request,
-	res: Response
-): Promise<void> => {
+// @desc Delete survey
+// @route DELETE /api/surveys/:id
+export const deleteSurvey = async(req: Request, res: Response): Promise<void> => {
 	try {
-		// Since there is only one survey, no need to look for it by ID
-		const survey = await Survey.findOne();
+		const survey = await Survey.findById(req.params.id);
 
 		if (!survey) {
-			res.status(404).json({
-				success: false,
-				message: "Survey not found",
-			});
+			res.status(404).json({success: false, message: "Survey not found."});
 			return;
 		}
 
-		// Delete the survey
-		await Survey.deleteOne({ _id: survey._id });
+		// Unlink from courses
+		await Course.updateMany({ surveyId: survey._id }, { surveyId: null });
 
-		res.status(200).json({
-			success: true,
-			message: "Survey deleted successfully",
-		});
+		const responseCount = await SurveyResponse.countDocuments({surveyId: survey._id});
+		if (responseCount > 0) {
+			// If there are responses, just mark as inactive instead of deleting
+			survey.isActive = false;
+			survey.courseIds = [];
+			await survey.save();
+		} else {
+			// No responses, safe to delete
+			await Survey.deleteOne({ _id: survey._id });
+		}
+
+		res.status(200).json({success: true, message: "Survey deleted successfully."});
 	} catch (error) {
 		if (error instanceof Error) {
-			res.status(500).json({ message: error.message });
+			res.status(500).json({success: false, message: error.message});
 		} else {
-			res.status(500).json({ message: "An unknown error occurred" });
+			res.status(500).json({success: false, message: "Internal service error."});
 		}
 	}
 };
+
+// @desc Assign survey to course
+// @route POST /api/surveys/:id/assign
+// @body {courseId}
+export const assignSurvey = async(req: Request, res: Response): Promise<void> => {
+	try {
+		const { courseId } = req.body;
+		if (!courseId) {
+			res.status(400).json({success: false, message: "courseId is required."});
+			return;
+		}
+
+		const survey = await Survey.findById(req.params.id);
+		if (!survey) {
+			res.status(404).json({success: false, message: "Survey not found."});
+			return;
+		}
+
+		// Add courseId, avoid duplicates
+		if (!survey.courseIds.includes(courseId)) {
+			survey.courseIds.push(courseId);
+			await survey.save();
+		}
+
+		await Course.findByIdAndUpdate(courseId, { surveyId: survey._id });
+
+		res.status(200).json({success: true, data: survey, message: "Survey assigned to course successfully."});
+	} catch (error) {
+		if (error instanceof Error) {
+			res.status(500).json({success: false, message: error.message});
+		} else {
+			res.status(500).json({success: false, message: "Internal service error."});
+		}
+	}
+};
+
+// @desc    Unassign survey from a course
+// @route   POST /api/surveys/:id/unassign
+// @body    { courseId }
+export const unassignSurvey = async (req: Request, res: Response): Promise<void> => {
+	try {
+		const { courseId } = req.body;
+		if (!courseId) {
+			res.status(400).json({ success: false, message: "courseId is required" });
+			return;
+		}
+ 
+		const survey = await Survey.findById(req.params.id);
+		if (!survey) {
+			res.status(404).json({ success: false, message: "Survey not found" });
+			return;
+		}
+ 
+		survey.courseIds = survey.courseIds.filter(
+			(id: any) => id.toString() !== courseId
+		) as any;
+		await survey.save();
+ 
+		await Course.findByIdAndUpdate(courseId, { surveyId: null });
+		res.status(200).json({ success: true, data: survey });
+	} catch (error) {
+		if (error instanceof Error) {
+			res.status(500).json({ success: false, message: error.message });
+		} else {
+			res.status(500).json({ success: false, message: "An unknown error occurred" });
+		}
+	}
+};
+
+
+
+// @desc    Duplicate survey as independent copy
+// @route   POST /api/surveys/:id/duplicate
+// @body    { name?, courseId? }
+export const duplicateSurvey = async (req: Request, res: Response): Promise<void> => {
+	try {
+		const { name, courseId } = req.body;
+		const original = await Survey.findById(req.params.id);
+ 
+		if (!original) {
+			res.status(404).json({ success: false, message: "Survey not found" });
+			return;
+		}
+ 
+		const duplicate = new Survey({
+			name: name || `${original.name} (Copy)`,
+			questions: [...original.questions],
+			courseIds: courseId ? [courseId] : [],
+			version: 1,
+			isActive: true,
+		});
+		await duplicate.save();
+ 
+		if (courseId) {
+			await Course.findByIdAndUpdate(courseId, { surveyId: duplicate._id });
+		}
+ 
+		res.status(201).json({ success: true, data: duplicate });
+	} catch (error) {
+		if (error instanceof Error) {
+			res.status(500).json({ success: false, message: error.message });
+		} else {
+			res.status(500).json({ success: false, message: "An unknown error occurred" });
+		}
+	}
+};
+			

--- a/backend/controllers/surveyResponseController.ts
+++ b/backend/controllers/surveyResponseController.ts
@@ -1,22 +1,26 @@
 import { Request, Response } from "express";
+import mongoose from "mongoose";
 import SurveyResponse from "../models/surveyResponseModel";
 import QuestionResponse from "../models/questionResponseModel";
+import Survey from "../models/surveyModel";
+import Course from "../models/courseModel";
+import Question from "../models/questionModel";
 
 // @desc    Get all survey responses or filter by query parameters
-// @route   GET /api/surveyResponses
+// @route   GET /api/surveyResponses?surveyId=&courseId=&userId=&startDate=&endDate=
 // @access  Public
 export const getSurveyResponses = async (
 	req: Request,
 	res: Response
 ): Promise<void> => {
 	try {
-		const { userId, startDate, endDate } = req.query;
+		const { userId, surveyId, courseId, startDate, endDate } = req.query;
 
 		let filter: any = {};
 
-		if (userId) {
-			filter.userId = userId;
-		}
+		if (userId) filter.userId = userId;
+		if (surveyId) filter.surveyId = surveyId;
+		if (courseId) filter.courseId = courseId;
 
 		if (startDate || endDate) {
 			filter.dateCompleted = {};
@@ -30,6 +34,8 @@ export const getSurveyResponses = async (
 
 		const surveyResponses = await SurveyResponse.find(filter)
 			.populate("answers")
+			.populate("surveyId", "name version")
+			.populate("courseId", "className")
 			.exec();
 
 		res.status(200).json({
@@ -48,6 +54,7 @@ export const getSurveyResponses = async (
 
 // @desc    Create a new survey response
 // @route   POST /api/surveyResponses
+// @body    {userId, answers: string[], surveyId, courseId}
 // @access  Public
 export const createSurveyResponse = async (
 	req: Request,
@@ -55,7 +62,7 @@ export const createSurveyResponse = async (
 ): Promise<void> => {
 	try {
 		// answers are a list of QuestionResponse IDs and QuestionResponse objects must be created first before calling this endpoint
-		const { userId, dateCompleted, answers } = req.body;
+		const { userId, answers, surveyId, courseId } = req.body;
 
 		if (!userId || !answers || answers.length === 0) {
 			res.status(400).json({
@@ -65,10 +72,20 @@ export const createSurveyResponse = async (
 			return;
 		}
 
+		if (!surveyId || !courseId) {
+			res.status(400).json({
+				success: false,
+				message: "Please provide surveyId and courseId.",
+			});
+			return;
+		}
+
+
 		const newSurveyResponse = new SurveyResponse({
 			userId,
-			dateCompleted,
 			answers,
+			surveyId,
+			courseId,
 		});
 
 		const savedSurveyResponse = await newSurveyResponse.save();
@@ -95,40 +112,220 @@ export const createSurveyResponse = async (
 //   res: Response
 // ): Promise<void> => {};
 
-// @desc    Delete a survey response
+// @desc    Delete a survey response and its question responses
 // @route   DELETE /api/surveyResponses/:id
-// @access  Public
-export const deleteSurveyResponse = async (
-	req: Request,
-	res: Response
-): Promise<void> => {
+export const deleteSurveyResponse = async (req: Request, res: Response): Promise<void> => {
 	try {
 		const { id } = req.params;
-
 		const surveyResponse = await SurveyResponse.findById(id);
-
+ 
 		if (!surveyResponse) {
-			res.status(404).json({
-				success: false,
-				message: "Survey response not found.",
-			});
+			res.status(404).json({ success: false, message: "Survey response not found." });
 			return;
 		}
-
+ 
 		await QuestionResponse.deleteMany({ _id: { $in: surveyResponse.answers } });
-
 		await SurveyResponse.deleteOne({ _id: id });
-
+ 
 		res.status(200).json({
 			success: true,
-			message:
-				"Survey response and associated question responses deleted successfully.",
+			message: "Survey response and associated question responses deleted.",
 		});
 	} catch (error) {
 		console.error(error);
-		res.status(500).json({
-			success: false,
-			message: "Internal service error.",
-		});
+		res.status(500).json({ success: false, message: "Internal service error." });
+	}
+};
+
+// @desc Get aggregated survey response statistics
+// @route GET /api/surveyResponse/stats?surveyId=&courseId=
+//
+// Returns array of 
+// {
+//   surveyId, surveyName, surveyVersion,
+//   courseId, courseName,
+//   totalResponses,
+//   questions: [{
+//     questionId, questionText, answerType, options,
+//     totalAnswered, breakdown: { "option": count }
+//   }]
+// }
+export const getSurveyResponseStats = async (req: Request, res: Response): Promise<void> => {
+	try {
+		const { surveyId, courseId } = req.query;
+		const matchStage: any = {};
+
+		if (surveyId) matchStage.surveyId = new mongoose.Types.ObjectId(surveyId as string);
+		if (courseId) matchStage.courseId = new mongoose.Types.ObjectId(courseId as string);
+
+		// Group responses by survey + courses
+		const grouped = await SurveyResponse.aggregate([
+			{ $match: matchStage },
+			{
+				$group: {
+					_id: { surveyId: "$surveyId", courseId: "$courseId" },
+					totalResponses: { $sum: 1 },
+				},
+			},
+		]);
+
+		const results = [];
+
+		for (const group of grouped) {
+			const survey = await Survey.findById(group._id.surveyId).populate("questions");
+			const course = group._id.courseId ? await Course.findById(group._id.courseId) : null;
+
+			if (!survey) continue;
+
+			// Get all QuestionResponse IDs for this survey+course combo
+			const answerIds = await SurveyResponse.find({
+				surveyId: group._id.surveyId,
+				courseId: group._id.courseId,
+			}).distinct("answers");
+
+			// For each question in the survey, calculate breakdown of answers
+			const questionStats = [];
+			for (const question of survey.questions as any[]) {
+				const questionResponses = await QuestionResponse.find({
+					questionId: question._id,
+					_id: { $in: answerIds },
+				});
+
+				const breakdown: Record<string, number> = {};
+				for (const qr of questionResponses) {
+					const parts = question.answerType === "Multi-select"
+						? qr.answer.split(",").map((a: string) => a.trim())
+						: [qr.answer];
+					for (const part of parts) {
+						breakdown[part] = (breakdown[part] || 0) + 1;
+					}
+				}
+ 
+				questionStats.push({
+					questionId: question._id,
+					questionText: question.question,
+					answerType: question.answerType,
+					options: question.answers || [],
+					totalAnswered: questionResponses.length,
+					breakdown,
+				});
+			}
+ 
+			results.push({
+				surveyId: group._id.surveyId,
+				surveyName: survey.name,
+				surveyVersion: survey.version,
+				courseId: group._id.courseId,
+				courseName: course?.className || "Unknown Course",
+				totalResponses: group.totalResponses,
+				questions: questionStats,
+			});
+		}
+ 
+		res.status(200).json({ success: true, data: results });
+	} catch (error) {
+		console.error(error);
+		res.status(500).json({ success: false, message: "Internal service error." });
+	}
+};
+
+// @desc    Export survey responses as CSV
+// @route   GET /api/surveyResponses/export?surveyId=&courseId=&format=row-per-response|row-per-answer
+export const exportSurveyResponses = async (req: Request, res: Response): Promise<void> => {
+	try {
+		const { surveyId, courseId, format = "row-per-response" } = req.query;
+		const filter: any = {};
+ 
+		if (surveyId) filter.surveyId = surveyId;
+		if (courseId) filter.courseId = courseId;
+ 
+		const responses = await SurveyResponse.find(filter)
+			.populate("answers")
+			.populate("surveyId", "name questions")
+			.populate("courseId", "className")
+			.exec();
+ 
+		// Collect all surveys referenced
+		const surveyIds = [...new Set(responses.map((r: any) => r.surveyId?._id?.toString()).filter(Boolean))];
+		const surveys = await Survey.find({ _id: { $in: surveyIds } }).populate("questions");
+		const surveyMap = new Map(surveys.map((s: any) => [s._id.toString(), s]));
+ 
+		// Helper to escape CSV cells
+		const escapeCell = (val: string) => `"${(val || "").replace(/"/g, '""')}"`;
+ 
+		if (format === "row-per-answer") {
+			// Normalized: one row per question-answer pair
+			const headers = [
+				"SurveyName", "CourseName", "UserId", "SubmittedAt",
+				"QuestionId", "QuestionText", "AnswerType", "Answer",
+			];
+ 
+			const rows: string[][] = [];
+			for (const resp of responses as any[]) {
+				const surveyName = resp.surveyId?.name || "Unknown";
+				const courseName = resp.courseId?.className || "Unknown";
+ 
+				for (const answer of resp.answers) {
+					const question = await Question.findById(answer.questionId);
+					rows.push([
+						surveyName, courseName, resp.userId,
+						resp.createdAt?.toISOString() || "",
+						answer.questionId?.toString() || "",
+						question?.question || "",
+						question?.answerType || "",
+						answer.answer || "",
+					]);
+				}
+			}
+ 
+			const csv = [headers.join(","), ...rows.map((r) => r.map(escapeCell).join(","))].join("\n");
+ 
+			res.setHeader("Content-Type", "text/csv");
+			res.setHeader("Content-Disposition", "attachment; filename=survey_responses.csv");
+			res.status(200).send(csv);
+		} else {
+			// Row per response: one row per user, questions as columns
+			const allQuestions: any[] = [];
+			const seen = new Set<string>();
+			for (const survey of surveys) {
+				for (const q of survey.questions as any[]) {
+					if (!seen.has(q._id.toString())) {
+						seen.add(q._id.toString());
+						allQuestions.push(q);
+					}
+				}
+			}
+ 
+			const headers = [
+				"SurveyName", "CourseName", "UserId", "SubmittedAt",
+				...allQuestions.map((q, i) => `${i + 1}. ${q.question}`),
+			];
+ 
+			const rows: string[][] = [];
+			for (const resp of responses as any[]) {
+				const surveyName = resp.surveyId?.name || "Unknown";
+				const courseName = resp.courseId?.className || "Unknown";
+ 
+				const answerMap = new Map<string, string>();
+				for (const answer of resp.answers) {
+					answerMap.set(answer.questionId?.toString() || "", answer.answer || "");
+				}
+ 
+				rows.push([
+					surveyName, courseName, resp.userId,
+					resp.createdAt?.toISOString() || "",
+					...allQuestions.map((q) => answerMap.get(q._id.toString()) || ""),
+				]);
+			}
+ 
+			const csv = [headers.join(","), ...rows.map((r) => r.map(escapeCell).join(","))].join("\n");
+ 
+			res.setHeader("Content-Type", "text/csv");
+			res.setHeader("Content-Disposition", "attachment; filename=survey_responses.csv");
+			res.status(200).send(csv);
+		}
+	} catch (error) {
+		console.error(error);
+		res.status(500).json({ success: false, message: "Internal service error." });
 	}
 };

--- a/backend/models/courseModel.ts
+++ b/backend/models/courseModel.ts
@@ -106,6 +106,7 @@ const CourseSchema: Schema = new Schema(
 				_id: false,
 			},
 		],
+		surveyId: { type: Schema.Types.ObjectId, ref: "Survey", default: null },
 	},
 	{
 		timestamps: true,

--- a/backend/models/courseModel.ts
+++ b/backend/models/courseModel.ts
@@ -35,6 +35,7 @@ export interface ICourse extends Document {
 	draft: boolean;
 	registrationLimit: number;
 	waitlist: { user: mongoose.Types.ObjectId | IUser; joinedAt: Date }[];
+	surveyId: mongoose.Types.ObjectId | null;
 }
 
 const CourseSchema: Schema = new Schema(

--- a/backend/models/surveyModel.ts
+++ b/backend/models/surveyModel.ts
@@ -5,8 +5,12 @@ import { IQuestion } from "./questionModel";
 export interface ISurvey extends Document {
 	// Define fields here:
 	id: string;
+	name: string;
 	questions: mongoose.Types.ObjectId[];
-	courseId: mongoose.Types.ObjectId;
+	courseIds: mongoose.Types.ObjectId[];
+	version: number;
+	parentSurveyId: mongoose.Types.ObjectId | null;
+	isActive: boolean;
 }
 
 // Define the schema with placeholders for fields (others will fill this in)

--- a/backend/models/surveyModel.ts
+++ b/backend/models/surveyModel.ts
@@ -13,6 +13,11 @@ export interface ISurvey extends Document {
 const surveySchema: Schema = new Schema(
 	{
 		// Define fields here:
+		name: {type: String, required: true},
+		courseIds: [{type: Schema.Types.ObjectId, ref: "Course"}],
+		version: {type: Number, default: 1},
+		parentSurveyId: {type: Schema.Types.ObjectId, ref: "Survey", default: null},
+		isActive: {type: Boolean, default: true}, 
 		questions: [
 			{
 				type: mongoose.Schema.Types.ObjectId,

--- a/backend/models/surveyResponseModel.ts
+++ b/backend/models/surveyResponseModel.ts
@@ -4,6 +4,8 @@ import QuestionResponse, { IQuestionResponse } from "./questionResponseModel";
 export interface ISurveyResponse extends Document {
 	userId: string;
 	answers: (mongoose.Types.ObjectId | IQuestionResponse)[];
+	surveyId: mongoose.Types.ObjectId;
+	courseId: mongoose.Types.ObjectId;
 }
 
 const surveyResponseSchema: Schema = new Schema(

--- a/backend/models/surveyResponseModel.ts
+++ b/backend/models/surveyResponseModel.ts
@@ -15,6 +15,8 @@ const surveyResponseSchema: Schema = new Schema(
 				ref: "QuestionResponse",
 			},
 		],
+		surveyId: { type: Schema.Types.ObjectId, ref: "Survey"},
+		courseId: { type: Schema.Types.ObjectId, ref: "Course"},
 	},
 	{
 		timestamps: true,

--- a/backend/routes/surveyResponseRoutes.ts
+++ b/backend/routes/surveyResponseRoutes.ts
@@ -2,11 +2,16 @@ import express from "express";
 import {
 	getSurveyResponses,
 	createSurveyResponse,
-	// updateSurveyResponse,
 	deleteSurveyResponse,
+	getSurveyResponseStats,
+	exportSurveyResponses,
 } from "../controllers/surveyResponseController";
-
+ 
 const router = express.Router();
+ 
+// Static routes BEFORE parameterized routes
+router.get("/stats", getSurveyResponseStats);
+router.get("/export", exportSurveyResponses);
 
 // GET all survey responses or filter by query parameters
 router.get("/", getSurveyResponses);
@@ -14,10 +19,7 @@ router.get("/", getSurveyResponses);
 // POST new survey response
 router.post("/", createSurveyResponse);
 
-// PUT update survey response by ID
-// router.put("/:id", updateSurveyResponse);
-
 // DELETE survey response by ID
 router.delete("/:id", deleteSurveyResponse);
-
+ 
 export default router;

--- a/backend/routes/surveyRoutes.ts
+++ b/backend/routes/surveyRoutes.ts
@@ -1,23 +1,40 @@
 import express from "express";
 import {
-	getSurvey,
-	// createSurvey,
+	getSurveys,
+	getSurveyById,
+	createSurvey,
 	updateSurvey,
 	deleteSurvey,
+	assignSurvey,
+	unassignSurvey,
+	duplicateSurvey,
 } from "../controllers/surveyController";
 
 const router = express.Router();
 
 // GET all surveys or filter by query parameters
-router.get("/", getSurvey);
+router.get("/", getSurveys);
+
+// GET survey by ID
+router.get("/:id", getSurveyById);
 
 // POST new survey
-// router.post("/", createSurvey);
+router.post("/", createSurvey);
+
 
 // PUT update survey by ID
-router.put("/", updateSurvey);
+router.put("/:id", updateSurvey);
 
 // DELETE survey by ID
 router.delete("/:id", deleteSurvey);
+
+// POST assign survey to course
+router.post("/:id/assign", assignSurvey);
+
+// POST unassign survey from course
+router.post("/:id/unassign", unassignSurvey);
+
+// POST duplicate survey
+router.post("/:id/duplicate", duplicateSurvey);
 
 export default router;

--- a/backend/scripts/migrateSurveys.ts
+++ b/backend/scripts/migrateSurveys.ts
@@ -1,0 +1,136 @@
+import mongoose from "mongoose";
+import dotenv from "dotenv";
+import path from "path";
+
+// Load env from backend root
+dotenv.config({ path: path.resolve(__dirname, "../.env") });
+
+import Survey from "../models/surveyModel";
+import Course from "../models/courseModel";
+import SurveyResponse from "../models/surveyResponseModel";
+
+async function migrate() {
+	const uri = process.env.MONGO_URI;
+	if (!uri) {
+		console.error("MONGO_URI not set in .env");
+		process.exit(1);
+	}
+
+	await mongoose.connect(uri);
+	console.log("Connected to MongoDB");
+
+	// --- Before counts ---
+	const surveyCount = await Survey.countDocuments();
+	const courseCount = await Course.countDocuments();
+	const responseCount = await SurveyResponse.countDocuments();
+	console.log(`\nBefore migration:`);
+	console.log(`  Surveys: ${surveyCount}`);
+	console.log(`  Courses: ${courseCount}`);
+	console.log(`  SurveyResponses: ${responseCount}`);
+
+	// --- Step 1: Find or create the survey ---
+	let survey = await Survey.findOne();
+
+	if (!survey) {
+		console.log("\nNo existing survey found. Creating empty General Survey...");
+		survey = new Survey({
+			name: "General Survey",
+			questions: [],
+			courseIds: [],
+			version: 1,
+			parentSurveyId: null,
+			isActive: true,
+		});
+		await survey.save();
+	} else {
+		console.log(`\nFound existing survey: ${survey._id}`);
+		// Update with new fields (won't overwrite if already set)
+		survey.name = survey.name || "General Survey";
+		survey.version = survey.version || 1;
+		survey.isActive = survey.isActive ?? true;
+		survey.parentSurveyId = survey.parentSurveyId || null;
+		await survey.save();
+		console.log(
+			`  Updated survey with name="${survey.name}", version=${survey.version}`
+		);
+	}
+
+	// --- Step 2: Link all courses to this survey ---
+	const courses = await Course.find();
+	const courseIds: mongoose.Types.ObjectId[] = [];
+
+	for (const course of courses) {
+		if (!course.surveyId) {
+			course.surveyId = survey._id as mongoose.Types.ObjectId;
+			await course.save();
+			console.log(
+				`  Linked course "${course.className}" -> survey ${survey._id}`
+			);
+		} else {
+			console.log(
+				`  Course "${course.className}" already has surveyId=${course.surveyId}, skipping`
+			);
+		}
+		courseIds.push(course._id as mongoose.Types.ObjectId);
+	}
+
+	// Update the survey's courseIds
+	survey.courseIds = courseIds;
+	await survey.save();
+	console.log(`  Set survey.courseIds to ${courseIds.length} courses`);
+
+	// --- Step 3: Backfill SurveyResponses ---
+	const responsesWithoutSurveyId = await SurveyResponse.countDocuments({
+		$or: [{ surveyId: null }, { surveyId: { $exists: false } }],
+	});
+
+	console.log(
+		`\n  Found ${responsesWithoutSurveyId} responses without surveyId`
+	);
+
+	if (responsesWithoutSurveyId > 0) {
+		const result = await SurveyResponse.updateMany(
+			{ $or: [{ surveyId: null }, { surveyId: { $exists: false } }] },
+			{ $set: { surveyId: survey._id } }
+		);
+		console.log(
+			`  Updated ${result.modifiedCount} responses with surveyId=${survey._id}`
+		);
+		console.log(
+			`  Note: courseId left as null — these will show as "Unknown Course" in analytics`
+		);
+	}
+
+	// --- Validation ---
+	const afterSurveys = await Survey.countDocuments();
+	const coursesWithSurvey = await Course.countDocuments({
+		surveyId: { $ne: null },
+	});
+	const responsesWithSurvey = await SurveyResponse.countDocuments({
+		surveyId: { $ne: null },
+	});
+	const responsesStillMissing = await SurveyResponse.countDocuments({
+		$or: [{ surveyId: null }, { surveyId: { $exists: false } }],
+	});
+
+	console.log(`\nAfter migration:`);
+	console.log(`  Surveys: ${afterSurveys}`);
+	console.log(`  Courses with surveyId: ${coursesWithSurvey}/${courseCount}`);
+	console.log(
+		`  Responses with surveyId: ${responsesWithSurvey}/${responseCount}`
+	);
+	console.log(`  Responses without surveyId: ${responsesStillMissing}`);
+
+	if (responsesStillMissing > 0) {
+		console.warn("\n⚠️  Some responses still missing surveyId!");
+	} else {
+		console.log("\n✅ Migration complete!");
+	}
+
+	await mongoose.disconnect();
+}
+
+migrate().catch((err) => {
+	console.error("Migration failed:", err);
+	process.exit(1);
+});

--- a/frontend/src/pages/Admin/ComponentPage/Component.tsx
+++ b/frontend/src/pages/Admin/ComponentPage/Component.tsx
@@ -34,7 +34,7 @@ function Button({ children, className }: ButtonProps) {
 
 interface InclusiveSupportPageProps {
 	workshop: any;
-	survey: any;
+	survey?: any;
 	certificate: any;
 }
 export default function Component({

--- a/frontend/src/pages/Admin/ComponentPage/SurveyCard.tsx
+++ b/frontend/src/pages/Admin/ComponentPage/SurveyCard.tsx
@@ -1,6 +1,5 @@
-import { Dispatch, SetStateAction } from "react";
-import Dropdown from "../../../components/dropdown-select";
-import { List, Pencil, Wifi } from "lucide-react";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { List, Pencil, Plus } from "lucide-react";
 import DisplayBar from "./DisplayBar";
 import { SurveyType } from "../../../shared/types/survey";
 import { useNavigate } from "react-router-dom";
@@ -11,97 +10,53 @@ import {
 import apiClient from "../../../services/apiClient";
 
 interface SurveyProps {
-	survey?: SurveyType;
 	prerequisites: { survey: string; certificate: string };
 	setPrerequisites: Dispatch<
 		SetStateAction<{ survey: string; certificate: string }>
 	>;
 }
 
-interface CheckboxProps {
-	label: string;
-	checked: boolean;
-	onChange: (checked: boolean) => void;
-}
-
-export function Checkbox({ label, checked, onChange }: CheckboxProps) {
-	return (
-		<label className="flex items-center space-x-1 cursor-pointer text-sm">
-			<input
-				type="checkbox"
-				checked={checked}
-				onChange={(e) => onChange(e.target.checked)}
-				className="form-checkbox h-4 w-4 text-blue-600 rounded border-gray-300 focus:ring focus:ring-blue-500"
-			/>
-			<span className="text-gray-600">{label}</span>
-		</label>
-	);
-}
-
-type SurveyDetailsProps = {
-	survey: SurveyType;
-};
-
-const defaultSurvey: SurveyType = {
-	id: "default_survey",
-	questions: [
-		{
-			id: "q1",
-			question: "What is your favorite programming language?",
-			isMCQ: true,
-			answers: ["JavaScript", "Python", "Java", "C++"],
-		},
-		{
-			id: "q2",
-			question: "Do you have prior programming experience?",
-			isMCQ: true,
-			answers: ["Yes", "No"],
-		},
-	],
-	createdAt: new Date(),
-	updatedAt: new Date(),
-};
-
-export const SurveyDetails = ({ survey }: SurveyDetailsProps) => {
-	return (
-		<div className="text-black text-sm font-medium space-y-2 w-full pt-4 pb-11 mb-24">
-			<p className="font-semibold">Survey</p>
-
-			<p>
-				<span className="font-semibold">Questions:</span>{" "}
-				{survey.questions.length}
-			</p>
-		</div>
-	);
-};
-
 export default function SurveyCard({
-	survey = defaultSurvey,
 	prerequisites,
 	setPrerequisites,
 }: SurveyProps) {
-	const formatMenuItems = [
-		{
-			label: "None Selected",
-			onClick: () =>
-				setPrerequisites((prev) => ({ ...prev, survey: "None Selected" })),
-		},
-		{
-			label: "Workshop",
-			onClick: () =>
-				setPrerequisites((prev) => ({ ...prev, survey: "Workshop" })),
-		},
-	];
-
 	const navigate = useNavigate();
 	const course = getCleanCourseData();
 	const setAllFields = useCourseEditStore((state) => state.setAllFields);
+	const [survey, setSurvey] = useState<SurveyType | null>(null);
+	const [loading, setLoading] = useState(false);
+
+	// Fetch the course's assigned survey
+	useEffect(() => {
+		const fetchSurvey = async () => {
+			if (!course.surveyId) return;
+			try {
+				setLoading(true);
+				const response = await apiClient.get(`/surveys/${course.surveyId}`);
+				const data = response.data.survey || response.data;
+				setSurvey({
+					id: data._id,
+					name: data.name || "Untitled",
+					questions: data.questions || [],
+					courseIds: data.courseIds || [],
+					version: data.version || 1,
+					isActive: data.isActive ?? true,
+					createdAt: data.createdAt,
+					updatedAt: data.updatedAt,
+				});
+			} catch (error) {
+				console.error("Error fetching survey:", error);
+			} finally {
+				setLoading(false);
+			}
+		};
+		fetchSurvey();
+	}, [course.surveyId]);
 
 	const handleEditClick = async () => {
-		console.log(course);
 		if (!course._id) {
 			try {
-				const res = await apiClient.post("/courses", course); // or course with defaults
+				const res = await apiClient.post("/courses", course);
 				const createdCourse = res.data.data;
 				setAllFields({ ...createdCourse });
 				navigate(`/admin/product/edit/${createdCourse._id}/survey`);
@@ -113,69 +68,87 @@ export default function SurveyCard({
 		}
 	};
 
+	const hasSurvey = !!course.surveyId && !!survey;
+
 	return (
 		<div className="border rounded-lg shadow p-4 bg-white w-full last:mr-6 h-[98%] pb-2">
 			<div>
-				<div className="flex flex-row">
-					<List />
+				<div className="flex flex-row items-center">
+					<List className="w-5 h-5" />
 					<h2 className="text-xl font-bold pl-2">Survey</h2>
 				</div>
 
-				<p className="text-sm text-gray-500 mb-5">
-					Survey has {survey.questions.length} questions{" "}
-				</p>
-				{/* <p className="text-sm font-medium">Prerequisites</p>
+				{loading ? (
+					<p className="text-sm text-gray-400 mt-2">Loading...</p>
+				) : hasSurvey ? (
+					<>
+						<p className="text-sm text-gray-700 font-medium mt-1">
+							{survey.name}
+						</p>
+						<p className="text-sm text-gray-500 mb-5">
+							{survey.questions.length} question
+							{survey.questions.length !== 1 ? "s" : ""} &middot; v
+							{survey.version}
+							{survey.courseIds.length > 1 && (
+								<span className="ml-1 text-amber-600">
+									(shared across {survey.courseIds.length} courses)
+								</span>
+							)}
+						</p>
 
-				<Dropdown
-					buttonLabel={`None Selected: ${prerequisites.survey}`}
-					menuItems={formatMenuItems}
-				/>
-				<div className="flex flex-col gap-2 mt-4">
-					<Checkbox
-						label={"Required?"}
-						checked={false}
-						onChange={function (checked: boolean): void {
-							throw new Error("Function not implemented.");
-						}}
-					/>
-					<Checkbox
-						label={"Hide when completed?"}
-						checked={false}
-						onChange={function (checked: boolean): void {
-							throw new Error("Function not implemented.");
-						}}
-					/>
-				</div> */}
-
-				<div className="mt-8 text-xs font-bold">Preview</div>
-				<div className="mt-2 border p-3 rounded-lg border-black h-[350px] relative flex items-center flex-col">
-					<p className="font-medium text-left w-full">Content</p>
-					<div className="flex justify-center">
-						<DisplayBar status={"survey"} />
-					</div>
-					<SurveyDetails survey={survey} />
-					<div className=" items-center w-[90%] mb-2">
-						<button className="bg-[#F79518] text-white py-2 px-4 rounded w-full mt-4">
-							<div className="flex flex-row justify-center">
-								<Pencil className="mr-2" />
-								Complete Survey
+						<div className="mt-4 text-xs font-bold">Preview</div>
+						<div className="mt-2 border p-3 rounded-lg border-gray-300 h-[350px] relative flex items-center flex-col overflow-y-auto">
+							<p className="font-medium text-left w-full mb-2">Content</p>
+							<div className="flex justify-center">
+								<DisplayBar status={"survey"} />
 							</div>
+							<div className="text-black text-sm font-medium space-y-2 w-full pt-4 pb-4">
+								<p className="font-semibold">{survey.name}</p>
+								<p>
+									<span className="font-semibold">Questions:</span>{" "}
+									{survey.questions.length}
+								</p>
+							</div>
+							<div className="items-center w-[90%] mb-2">
+								<button className="bg-[#F79518] text-white py-2 px-4 rounded w-full mt-4">
+									<div className="flex flex-row justify-center">
+										<Pencil className="mr-2 w-4 h-4" />
+										Complete Survey
+									</div>
+								</button>
+							</div>
+						</div>
+
+						<button
+							className="bg-[#8757A3] text-white py-2 px-4 rounded w-full mt-4 transition transform active:scale-95 hover:scale-105"
+							onClick={handleEditClick}
+						>
+							Edit Survey
 						</button>
-					</div>
-				</div>
+					</>
+				) : (
+					<>
+						<p className="text-sm text-gray-500 mt-2 mb-6">
+							No survey assigned to this course yet.
+						</p>
 
-				<button
-					className="bg-[#8757A3] text-white py-2 px-4 rounded w-full mt-4 transition transform active:scale-95 hover:scale-105"
-					onClick={handleEditClick}
-				>
-					Edit Component
-				</button>
-
-				{/* <div className="flex justify-center mt-2">
-					<button className="text-purple-600 underline transition-transform duration-300 ease-in-out hover:scale-105 active:scale-95">
-						Hide Component
-					</button>
-				</div> */}
+						<div className="flex flex-col gap-3 mt-4">
+							<button
+								className="bg-[#8757A3] text-white py-2.5 px-4 rounded-md w-full transition hover:bg-[#6d4a92] flex items-center justify-center gap-2"
+								onClick={handleEditClick}
+							>
+								<Plus className="w-4 h-4" />
+								Create New Survey
+							</button>
+							<button
+								className="text-[#8757A3] border border-[#8757A3] py-2.5 px-4 rounded-md w-full transition hover:bg-[#8757A3] hover:text-white"
+								onClick={handleEditClick}
+							>
+								Use Existing Survey
+							</button>
+						</div>
+					</>
+				)}
 			</div>
 		</div>
 	);

--- a/frontend/src/pages/Admin/SurveyPage/Survey.tsx
+++ b/frontend/src/pages/Admin/SurveyPage/Survey.tsx
@@ -1,40 +1,78 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { List, Trash2, X } from "lucide-react";
+import { List, Trash2, X, Eye, Copy, Link } from "lucide-react";
 import apiClient from "../../../services/apiClient";
-import { getCleanCourseData } from "../../../store/useCourseEditStore";
+import {
+	getCleanCourseData,
+	useCourseEditStore,
+} from "../../../store/useCourseEditStore";
+
+interface SurveyQuestion {
+	_id: string;
+	question: string;
+	explanation: string;
+	answerType: string;
+	answers: string[];
+	isRequired: boolean;
+	isEdited: boolean;
+}
+
+interface ExistingSurvey {
+	_id: string;
+	name: string;
+	questions: any[];
+	courseIds: string[];
+	version: number;
+}
 
 const Survey = () => {
 	const course = getCleanCourseData();
-
+	const setAllFields = useCourseEditStore((state) => state.setAllFields);
 	const navigate = useNavigate();
-	const [questions, setQuestions] = useState([
-		{
-			_id: "",
-			question: "",
-			explanation: "",
-			answerType: "Text Input",
-			answers: [""],
-			isRequired: false,
-			isEdited: false,
-		},
-	]);
+
+	const [surveyName, setSurveyName] = useState("");
+	const [questions, setQuestions] = useState<SurveyQuestion[]>([]);
 	const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [loading, setLoading] = useState(false);
 	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [surveyId, setSurveyId] = useState<string | null>(null);
+	const [linkedCourseIds, setLinkedCourseIds] = useState<string[]>([]);
 
+	// Versioning modal state
+	const [showVersionModal, setShowVersionModal] = useState(false);
+	const [courseOptions, setCourseOptions] = useState<
+		{ id: string; name: string; checked: boolean }[]
+	>([]);
+	const [pendingQuestionIds, setPendingQuestionIds] = useState<string[]>([]);
+
+	// Reuse survey state
+	const [showReuseModal, setShowReuseModal] = useState(false);
+	const [existingSurveys, setExistingSurveys] = useState<ExistingSurvey[]>([]);
+	const [previewSurvey, setPreviewSurvey] = useState<ExistingSurvey | null>(
+		null
+	);
+
+	// Load the survey for this course
 	useEffect(() => {
 		const fetchSurvey = async () => {
+			const sid = course.surveyId;
+			if (!sid) return;
+
 			try {
-				const response = await apiClient.get("/surveys"); // Fetch the existing survey
-				const surveyData = response.data;
-				console.log("survey: ", surveyData);
+				const response = await apiClient.get(`/surveys/${sid}`);
+				const surveyData = response.data.survey || response.data;
 
 				if (surveyData) {
 					setSurveyId(surveyData._id);
-					setQuestions(surveyData.questions);
+					setSurveyName(surveyData.name || "");
+					setLinkedCourseIds(surveyData.courseIds || []);
+					setQuestions(
+						(surveyData.questions || []).map((q: any) => ({
+							...q,
+							isEdited: false,
+						}))
+					);
 				}
 			} catch (error) {
 				console.error("Error fetching survey:", error);
@@ -43,13 +81,14 @@ const Survey = () => {
 		};
 
 		fetchSurvey();
-	}, []);
+	}, [course.surveyId]);
 
+	// Question editing handlers
 	const handleQuestionChange = (index: number, value: string) => {
-		const updatedQuestions = [...questions];
-		updatedQuestions[index].question = value;
-		updatedQuestions[index].isEdited = true;
-		setQuestions(updatedQuestions);
+		const updated = [...questions];
+		updated[index].question = value;
+		updated[index].isEdited = true;
+		setQuestions(updated);
 		setHasUnsavedChanges(true);
 	};
 
@@ -70,34 +109,32 @@ const Survey = () => {
 	};
 
 	const deleteQuestion = (index: number) => {
-		const updatedQuestions = questions.filter((_, i) => i !== index);
-		setQuestions(updatedQuestions);
+		setQuestions(questions.filter((_, i) => i !== index));
 		setHasUnsavedChanges(true);
 	};
 
 	const handleExplanationChange = (index: number, value: string) => {
-		const updatedQuestions = [...questions];
-		updatedQuestions[index].explanation = value;
-		updatedQuestions[index].isEdited = true;
-		setQuestions(updatedQuestions);
+		const updated = [...questions];
+		updated[index].explanation = value;
+		updated[index].isEdited = true;
+		setQuestions(updated);
 		setHasUnsavedChanges(true);
 	};
 
 	const handleRequiredChange = (index: number, value: boolean) => {
-		const updatedQuestions = [...questions];
-		updatedQuestions[index].isRequired = value;
-		setQuestions(updatedQuestions);
+		const updated = [...questions];
+		updated[index].isRequired = value;
+		setQuestions(updated);
 		setHasUnsavedChanges(true);
 	};
 
 	const handleAnswerTypeChange = (index: number, value: string) => {
-		const updatedQuestions = [...questions];
-		updatedQuestions[index].answerType = value;
-		// Reset options (for Multiple Choice and Multi-select)
+		const updated = [...questions];
+		updated[index].answerType = value;
 		if (value !== "Text Input") {
-			updatedQuestions[index].answers = [""];
+			updated[index].answers = [""];
 		}
-		setQuestions(updatedQuestions);
+		setQuestions(updated);
 		setHasUnsavedChanges(true);
 	};
 
@@ -106,57 +143,64 @@ const Survey = () => {
 		oIndex: number,
 		value: string
 	) => {
-		const updatedQuestions = [...questions];
-		updatedQuestions[qIndex].answers[oIndex] = value;
-		setQuestions(updatedQuestions);
+		const updated = [...questions];
+		updated[qIndex].answers[oIndex] = value;
+		setQuestions(updated);
 		setHasUnsavedChanges(true);
 	};
 
 	const addOption = (qIndex: number) => {
-		const updatedQuestions = [...questions];
-		updatedQuestions[qIndex].answers.push("");
-		setQuestions(updatedQuestions);
+		const updated = [...questions];
+		updated[qIndex].answers.push("");
+		setQuestions(updated);
 		setHasUnsavedChanges(true);
 	};
 
 	const deleteOption = (qIndex: number, oIndex: number) => {
-		const updatedQuestions = [...questions];
-		updatedQuestions[qIndex].answers.splice(oIndex, 1);
-		setQuestions(updatedQuestions);
+		const updated = [...questions];
+		updated[qIndex].answers.splice(oIndex, 1);
+		setQuestions(updated);
 		setHasUnsavedChanges(true);
 	};
 
-	// Confirm before navigating away if there are unsaved changes
+	// Unsaved changes warning
 	useEffect(() => {
 		const handleBeforeUnload = (event: BeforeUnloadEvent) => {
 			if (hasUnsavedChanges) {
-				// Prevent the default action and show the confirmation dialog in modern browsers
 				event.preventDefault();
 			}
 		};
-
 		window.addEventListener("beforeunload", handleBeforeUnload);
-
-		return () => {
-			window.removeEventListener("beforeunload", handleBeforeUnload);
-		};
+		return () => window.removeEventListener("beforeunload", handleBeforeUnload);
 	}, [hasUnsavedChanges]);
 
-	const handleStay = () => {
-		setIsModalOpen(false);
+	const handleLeave = () => {
+		navigate(`/admin/product/edit/${course._id}/components`);
 	};
 
-	const handleLeave = () => {
-		// setIsModalOpen(false);
-		// Console log that the user is leaving
-		// console.log("User left the page.");
-
-		navigate(`/admin/product/edit/${course._id}/components`);
+	// Create question documents for edited questions, return array of IDs
+	const createQuestionDocs = async (): Promise<string[]> => {
+		return Promise.all(
+			questions.map(async (q) => {
+				if (q.isEdited || !q._id) {
+					const response = await apiClient.post("/questions", {
+						question: q.question,
+						explanation: q.explanation,
+						answerType: q.answerType,
+						answers: q.answers || [],
+						isRequired: q.isRequired,
+					});
+					return response.data._id;
+				}
+				return q._id;
+			})
+		);
 	};
 
 	const handleSaveSurvey = async () => {
 		setLoading(true);
 		setErrorMessage(null);
+
 		try {
 			if (questions.length === 0) {
 				setErrorMessage("At least one question is required.");
@@ -164,47 +208,61 @@ const Survey = () => {
 				return;
 			}
 
-			// First, create the questions
-			const createdQuestions = await Promise.all(
-				questions.map(async (q) => {
-					if (q.isEdited) {
-						// If question is edited, create a new question
-						const response = await apiClient.post("/questions", {
-							question: q.question,
-							explanation: q.explanation,
-							answerType: q.answerType,
-							answers: q.answers || [],
-							isRequired: q.isRequired,
-						});
-						return response.data._id; // Return new question's ID
-					} else {
-						// If question is not edited, return the existing question ID
-						return q._id; // Assume _id exists if it's an existing question
-					}
-				})
-			);
+			if (!surveyName.trim()) {
+				setErrorMessage("Survey name is required.");
+				setLoading(false);
+				return;
+			}
 
-			console.log(createdQuestions);
-
-			// Create survey data to send to backend
-			const surveyData = {
-				questions: createdQuestions,
-			};
+			const questionIds = await createQuestionDocs();
 
 			if (surveyId) {
-				// If surveyId exists, update the existing survey
-				const response = await apiClient.put(`/surveys`, surveyData);
-				console.log("data from survey after saving question: ", response.data);
-				alert("Survey saved successfully!");
-				setHasUnsavedChanges(false);
-				setSurveyId(response.data._id);
+				// Check if survey is shared and has responses — backend versioning handles this,
+				// but we need to ask the user which courses to update
+				if (linkedCourseIds.length > 1) {
+					// Fetch course names for the modal
+					const coursesResponse = await apiClient.get("/courses");
+					const allCourses = coursesResponse.data.data || [];
+					const options = linkedCourseIds.map((cid) => {
+						const found = allCourses.find((c: any) => c._id === cid);
+						return {
+							id: cid,
+							name: found?.className || "Unknown",
+							checked: true,
+						};
+					});
+					setCourseOptions(options);
+					setPendingQuestionIds(questionIds);
+					setShowVersionModal(true);
+				} else {
+					// Single course or no courses — just update
+					const response = await apiClient.put(`/surveys/${surveyId}`, {
+						name: surveyName,
+						questions: questionIds,
+					});
+					const data = response.data.data;
+					setSurveyId(data._id);
+					setLinkedCourseIds(data.courseIds || []);
+					setAllFields({ surveyId: data._id });
+					alert("Survey saved successfully!");
+					setHasUnsavedChanges(false);
+				}
 			} else {
-				// Create a new survey if there is no surveyId
-				const response = await apiClient.post("/api/surveys", surveyData);
-				console.error("No surveyId");
+				// Create new survey
+				const courseIds = course._id ? [course._id] : [];
+				const response = await apiClient.post("/surveys", {
+					name: surveyName,
+					questions: questionIds,
+					courseIds,
+				});
+				const data = response.data.data;
+				setSurveyId(data._id);
+				setLinkedCourseIds(data.courseIds || []);
+				setAllFields({ surveyId: data._id });
+				alert("Survey created successfully!");
+				setHasUnsavedChanges(false);
 			}
 		} catch (err) {
-			// Handle errors from the backend
 			console.error("Error saving survey:", err);
 			setErrorMessage("Error saving survey. Please try again.");
 		} finally {
@@ -212,20 +270,151 @@ const Survey = () => {
 		}
 	};
 
+	// Confirm versioning — which courses get the new version
+	const handleConfirmVersion = async () => {
+		try {
+			setLoading(true);
+			const courseIdsToUpdate = courseOptions
+				.filter((c) => c.checked)
+				.map((c) => c.id);
+
+			const response = await apiClient.put(`/surveys/${surveyId}`, {
+				name: surveyName,
+				questions: pendingQuestionIds,
+				courseIdsToUpdate,
+			});
+			const data = response.data.data;
+			setSurveyId(data._id);
+			setLinkedCourseIds(data.courseIds || []);
+			setAllFields({ surveyId: data._id });
+			setShowVersionModal(false);
+			alert("Survey saved successfully!");
+			setHasUnsavedChanges(false);
+		} catch (err) {
+			console.error("Error saving versioned survey:", err);
+			setErrorMessage("Error saving survey. Please try again.");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	// Reuse survey flow
+	const handleOpenReuse = async () => {
+		try {
+			const response = await apiClient.get("/surveys");
+			const all = response.data.data || [];
+			setExistingSurveys(all);
+			setShowReuseModal(true);
+		} catch (error) {
+			console.error("Error fetching surveys:", error);
+		}
+	};
+
+	const handleShareSurvey = async (survey: ExistingSurvey) => {
+		try {
+			if (!course._id) return;
+			await apiClient.post(`/surveys/${survey._id}/assign`, {
+				courseId: course._id,
+			});
+			setAllFields({ surveyId: survey._id });
+			setSurveyId(survey._id);
+			setSurveyName(survey.name);
+			setLinkedCourseIds([...survey.courseIds, course._id]);
+			setQuestions(
+				survey.questions.map((q: any) => ({ ...q, isEdited: false }))
+			);
+			setShowReuseModal(false);
+			setHasUnsavedChanges(false);
+		} catch (error) {
+			console.error("Error sharing survey:", error);
+		}
+	};
+
+	const handleDuplicateSurvey = async (survey: ExistingSurvey) => {
+		try {
+			const response = await apiClient.post(
+				`/surveys/${survey._id}/duplicate`,
+				{
+					courseId: course._id || undefined,
+				}
+			);
+			const data = response.data.data;
+			setAllFields({ surveyId: data._id });
+			setSurveyId(data._id);
+			setSurveyName(data.name);
+			setLinkedCourseIds(data.courseIds || []);
+			setQuestions(
+				(data.questions || []).map((q: any) => ({ ...q, isEdited: false }))
+			);
+			setShowReuseModal(false);
+			setHasUnsavedChanges(false);
+
+			// Re-fetch to populate questions
+			const fetched = await apiClient.get(`/surveys/${data._id}`);
+			const full = fetched.data.survey || fetched.data;
+			setQuestions(
+				(full.questions || []).map((q: any) => ({ ...q, isEdited: false }))
+			);
+		} catch (error) {
+			console.error("Error duplicating survey:", error);
+		}
+	};
+
 	return (
 		<div className="bg-white p-6">
-			<div className="flex items-center space-x-2">
-				<List className="w-6 h-6" />
-				<h1 className="text-2xl font-semibold text-gray-800">Survey</h1>
+			{/* Header */}
+			<div className="flex items-center justify-between mb-6">
+				<div className="flex items-center space-x-2">
+					<List className="w-6 h-6" />
+					<h1 className="text-2xl font-semibold text-gray-800">
+						{surveyId ? "Edit Survey" : "Create Survey"}
+					</h1>
+				</div>
+				{!surveyId && (
+					<button
+						onClick={handleOpenReuse}
+						className="text-[#8757A3] border border-[#8757A3] py-2 px-4 rounded-md hover:bg-[#8757A3] hover:text-white transition text-sm"
+					>
+						Use Existing Survey
+					</button>
+				)}
 			</div>
+
+			{/* Survey Name */}
+			<div className="mb-6">
+				<label htmlFor="survey-name" className="block font-semibold mb-2">
+					Survey Name
+				</label>
+				<input
+					type="text"
+					id="survey-name"
+					value={surveyName}
+					onChange={(e) => {
+						setSurveyName(e.target.value);
+						setHasUnsavedChanges(true);
+					}}
+					placeholder="Enter survey name"
+					className="w-1/2 p-3 border rounded-md"
+				/>
+			</div>
+
+			{/* Linked courses info */}
+			{linkedCourseIds.length > 1 && (
+				<div className="mb-6 p-3 bg-amber-50 border border-amber-200 rounded-md text-sm text-amber-800">
+					This survey is shared across {linkedCourseIds.length} courses.
+					Editing will prompt you to choose which courses receive the update.
+				</div>
+			)}
 
 			{/* Questions */}
 			<div>
 				{questions.map((question, index) => (
-					<div key={index} className="space-y-4 mt-12">
-						{/* Question */}
+					<div key={index} className="space-y-4 mt-8 pb-6 border-b border-gray-100">
 						<div className="flex items-center justify-between">
 							<div className="flex items-center space-x-3">
+								<span className="flex-shrink-0 w-7 h-7 rounded-full bg-[#8757a3] text-white text-sm flex items-center justify-center font-medium">
+									{index + 1}
+								</span>
 								<label
 									htmlFor={`question-${index}`}
 									className="block font-semibold"
@@ -234,9 +423,9 @@ const Survey = () => {
 								</label>
 								<button
 									onClick={() => deleteQuestion(index)}
-									className="text-red-600 flex items-center space-x-2"
+									className="text-red-500 hover:text-red-700 transition"
 								>
-									<Trash2 className="w-5 h-5" />
+									<Trash2 className="w-4 h-4" />
 								</button>
 							</div>
 						</div>
@@ -251,35 +440,38 @@ const Survey = () => {
 							/>
 						</div>
 
-						{/* Explanation Text */}
 						<div>
 							<label
 								htmlFor={`explanation-${index}`}
-								className="block font-semibold"
+								className="block font-semibold text-sm"
 							>
 								Explanation Text
 							</label>
 							<textarea
 								id={`explanation-${index}`}
 								value={question.explanation}
-								onChange={(e) => handleExplanationChange(index, e.target.value)}
+								onChange={(e) =>
+									handleExplanationChange(index, e.target.value)
+								}
 								placeholder="Enter optional explanation that will appear above the question."
 								className="w-3/4 mt-2 p-3 border rounded-md"
+								rows={2}
 							/>
 						</div>
 
-						{/* Answer Type */}
 						<div>
 							<label
 								htmlFor={`answer-type-${index}`}
-								className="block font-semibold"
+								className="block font-semibold text-sm"
 							>
 								Answer Type
 							</label>
 							<select
 								id={`answer-type-${index}`}
 								value={question.answerType}
-								onChange={(e) => handleAnswerTypeChange(index, e.target.value)}
+								onChange={(e) =>
+									handleAnswerTypeChange(index, e.target.value)
+								}
 								className="w-3/4 mt-2 p-3 border rounded-md"
 							>
 								<option value="Text Input">Text Input</option>
@@ -288,10 +480,9 @@ const Survey = () => {
 							</select>
 						</div>
 
-						{/* Options (for Multiple Choice) */}
 						{(question.answerType === "Multiple Choice" ||
 							question.answerType === "Multi-select") && (
-							<div className="mt-4 space-y-3 pl-16">
+							<div className="mt-4 space-y-3 pl-10">
 								{question.answers.map((answer, oIndex) => (
 									<div key={oIndex} className="flex items-center space-x-3">
 										<input
@@ -305,27 +496,28 @@ const Survey = () => {
 										/>
 										<button
 											onClick={() => deleteOption(index, oIndex)}
-											className="text-red-600"
+											className="text-red-500 hover:text-red-700"
 										>
-											<Trash2 className="w-5 h-5" />
+											<Trash2 className="w-4 h-4" />
 										</button>
 									</div>
 								))}
 								<button
 									onClick={() => addOption(index)}
-									className="mt-2 text-[#8757A3] border border-[#8757A3] py-2 px-4 rounded-md hover:bg-[#8757A3] hover:text-white focus:ring-2 focus:ring-[#8757A3]"
+									className="text-[#8757A3] border border-[#8757A3] py-2 px-4 rounded-md hover:bg-[#8757A3] hover:text-white transition text-sm"
 								>
 									Add Option
 								</button>
 							</div>
 						)}
 
-						{/* Required Checkbox */}
 						<div className="mt-2 flex items-center">
 							<input
 								type="checkbox"
 								checked={question.isRequired}
-								onChange={(e) => handleRequiredChange(index, e.target.checked)}
+								onChange={(e) =>
+									handleRequiredChange(index, e.target.checked)
+								}
 								className="mr-2"
 							/>
 							<label className="text-sm">Required</label>
@@ -333,40 +525,38 @@ const Survey = () => {
 					</div>
 				))}
 
-				{/* Add Question Button */}
 				<button
 					onClick={addQuestion}
-					className="mt-4 bg-[#8757A3] text-white py-2 px-4 rounded-md hover:bg-[#6d4a92] focus:ring-2 focus:ring-[#8757A3]"
+					className="mt-4 bg-[#8757A3] text-white py-2 px-4 rounded-md hover:bg-[#6d4a92] transition"
 				>
 					Add Question
 				</button>
 
-				<div className="flex flex-col items-end mt-4 space-y-2">
-					{/* Error Message Display */}
+				<div className="flex flex-col items-end mt-6 space-y-2">
 					{errorMessage && (
-						<div className="text-red-600 mt-4">{errorMessage}</div>
+						<div className="text-red-600 text-sm">{errorMessage}</div>
 					)}
 
-					{/* Save Button */}
 					<button
 						onClick={handleSaveSurvey}
-						className="w-[200px] bg-[#8757A3] text-white py-2 px-4 rounded-md hover:bg-[#6d4a92] focus:ring-2 focus:ring-[#8757A3]"
+						className="w-[200px] bg-[#8757A3] text-white py-2 px-4 rounded-md hover:bg-[#6d4a92] transition"
 						disabled={loading}
 					>
 						{loading ? "Saving..." : "Save"}
 					</button>
 
-					{/* Exit Button */}
 					<button
-						onClick={() => handleLeave()}
-						className="w-[200px] text-[#8757A3] border border-[#8757A3] py-2 px-4 rounded-md hover:bg-[#8757A3] hover:text-white focus:ring-2 focus:ring-[#8757A3]"
+						onClick={() =>
+							hasUnsavedChanges ? setIsModalOpen(true) : handleLeave()
+						}
+						className="w-[200px] text-[#8757A3] border border-[#8757A3] py-2 px-4 rounded-md hover:bg-[#8757A3] hover:text-white transition"
 					>
 						Exit
 					</button>
 				</div>
 			</div>
 
-			{/* Modal */}
+			{/* Unsaved changes modal */}
 			{isModalOpen && (
 				<div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
 					<div className="bg-white w-96 p-6 rounded-lg shadow-lg relative">
@@ -377,23 +567,221 @@ const Survey = () => {
 							<X className="w-6 h-6" />
 						</button>
 						<h2 className="text-xl font-semibold">Unsaved Changes</h2>
-						<p className="mt-2">
-							It looks like you have edits that aren’t saved yet. Are you sure
-							you want to leave?
+						<p className="mt-2 text-gray-600">
+							You have edits that aren't saved yet. Are you sure you want to
+							leave?
 						</p>
 						<div className="mt-4 flex space-x-4 justify-end">
 							<button
-								onClick={handleStay}
-								className="text-[#6C6C6C] border border-[#6C6C6C] py-2 px-4 rounded-md hover:bg-gray-100"
+								onClick={() => setIsModalOpen(false)}
+								className="text-gray-600 border border-gray-300 py-2 px-4 rounded-md hover:bg-gray-100"
 							>
 								Stay
 							</button>
 							<button
 								onClick={handleLeave}
-								className="text-white bg-[#CB2F2F] py-2 px-4 rounded-md hover:bg-[#9e2a2a]"
+								className="text-white bg-red-500 py-2 px-4 rounded-md hover:bg-red-600"
 							>
 								Leave
 							</button>
+						</div>
+					</div>
+				</div>
+			)}
+
+			{/* Versioning modal — choose which courses get the update */}
+			{showVersionModal && (
+				<div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
+					<div className="bg-white w-[480px] p-6 rounded-lg shadow-lg relative">
+						<button
+							onClick={() => setShowVersionModal(false)}
+							className="absolute top-2 right-2 text-gray-400 hover:text-gray-600"
+						>
+							<X className="w-6 h-6" />
+						</button>
+						<h2 className="text-xl font-semibold mb-2">
+							Update Shared Survey
+						</h2>
+						<p className="text-sm text-gray-600 mb-4">
+							This survey is used by multiple courses. Select which courses
+							should receive the updated version. Unselected courses will keep
+							the current version.
+						</p>
+						<div className="space-y-2 max-h-60 overflow-y-auto">
+							{courseOptions.map((opt) => (
+								<label
+									key={opt.id}
+									className="flex items-center gap-3 p-2 rounded-md hover:bg-gray-50 cursor-pointer"
+								>
+									<input
+										type="checkbox"
+										checked={opt.checked}
+										onChange={(e) => {
+											setCourseOptions((prev) =>
+												prev.map((o) =>
+													o.id === opt.id
+														? { ...o, checked: e.target.checked }
+														: o
+												)
+											);
+										}}
+										className="w-4 h-4"
+									/>
+									<span className="text-gray-700">{opt.name}</span>
+								</label>
+							))}
+						</div>
+						<div className="mt-6 flex justify-end space-x-3">
+							<button
+								onClick={() => setShowVersionModal(false)}
+								className="text-gray-600 border border-gray-300 py-2 px-4 rounded-md hover:bg-gray-100"
+							>
+								Cancel
+							</button>
+							<button
+								onClick={handleConfirmVersion}
+								disabled={loading}
+								className="bg-[#8757A3] text-white py-2 px-4 rounded-md hover:bg-[#6d4a92] transition"
+							>
+								{loading ? "Saving..." : "Save & Update"}
+							</button>
+						</div>
+					</div>
+				</div>
+			)}
+
+			{/* Reuse existing survey modal */}
+			{showReuseModal && (
+				<div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-50">
+					<div className="bg-white w-[640px] max-h-[80vh] rounded-lg shadow-lg relative flex flex-col">
+						<div className="flex items-center justify-between p-6 border-b">
+							<h2 className="text-xl font-semibold">Use Existing Survey</h2>
+							<button
+								onClick={() => {
+									setShowReuseModal(false);
+									setPreviewSurvey(null);
+								}}
+								className="text-gray-400 hover:text-gray-600"
+							>
+								<X className="w-6 h-6" />
+							</button>
+						</div>
+
+						<div className="flex-1 overflow-y-auto p-6">
+							{previewSurvey ? (
+								// Preview mode
+								<div>
+									<button
+										onClick={() => setPreviewSurvey(null)}
+										className="text-sm text-[#8757A3] hover:underline mb-4"
+									>
+										&larr; Back to list
+									</button>
+									<h3 className="text-lg font-semibold mb-1">
+										{previewSurvey.name}
+									</h3>
+									<p className="text-sm text-gray-500 mb-4">
+										{previewSurvey.questions.length} question
+										{previewSurvey.questions.length !== 1 ? "s" : ""} &middot;
+										v{previewSurvey.version}
+									</p>
+									<div className="space-y-3">
+										{previewSurvey.questions.map((q: any, idx: number) => (
+											<div
+												key={q._id || idx}
+												className="bg-gray-50 p-3 rounded-md"
+											>
+												<p className="font-medium text-sm">
+													{idx + 1}. {q.question}
+												</p>
+												<p className="text-xs text-gray-400 mt-1">
+													{q.answerType}
+													{q.isRequired ? " (Required)" : ""}
+												</p>
+												{q.answers && q.answers.length > 0 && (
+													<ul className="mt-2 space-y-1">
+														{q.answers.map((a: string, ai: number) => (
+															<li
+																key={ai}
+																className="text-xs text-gray-600 pl-4"
+															>
+																&bull; {a}
+															</li>
+														))}
+													</ul>
+												)}
+											</div>
+										))}
+									</div>
+									<div className="mt-6 flex gap-3">
+										<button
+											onClick={() => handleShareSurvey(previewSurvey)}
+											className="flex items-center gap-2 bg-[#8757A3] text-white py-2 px-4 rounded-md hover:bg-[#6d4a92] transition text-sm"
+										>
+											<Link className="w-4 h-4" />
+											Share (Link)
+										</button>
+										<button
+											onClick={() => handleDuplicateSurvey(previewSurvey)}
+											className="flex items-center gap-2 text-[#8757A3] border border-[#8757A3] py-2 px-4 rounded-md hover:bg-[#8757A3] hover:text-white transition text-sm"
+										>
+											<Copy className="w-4 h-4" />
+											Duplicate (Copy)
+										</button>
+									</div>
+								</div>
+							) : (
+								// List mode
+								<div className="space-y-3">
+									{existingSurveys.length === 0 ? (
+										<p className="text-gray-500 text-center py-8">
+											No existing surveys found.
+										</p>
+									) : (
+										existingSurveys.map((s) => (
+											<div
+												key={s._id}
+												className="flex items-center justify-between p-4 border rounded-lg hover:bg-gray-50 transition"
+											>
+												<div>
+													<p className="font-medium text-gray-800">
+														{s.name}
+													</p>
+													<p className="text-xs text-gray-500">
+														{s.questions.length} question
+														{s.questions.length !== 1 ? "s" : ""} &middot;
+														v{s.version} &middot; {s.courseIds.length} course
+														{s.courseIds.length !== 1 ? "s" : ""}
+													</p>
+												</div>
+												<div className="flex gap-2">
+													<button
+														onClick={() => setPreviewSurvey(s)}
+														className="p-2 hover:bg-gray-100 rounded-md transition"
+														title="Preview"
+													>
+														<Eye className="w-4 h-4 text-gray-500" />
+													</button>
+													<button
+														onClick={() => handleShareSurvey(s)}
+														className="p-2 hover:bg-gray-100 rounded-md transition"
+														title="Share (link same survey)"
+													>
+														<Link className="w-4 h-4 text-[#8757A3]" />
+													</button>
+													<button
+														onClick={() => handleDuplicateSurvey(s)}
+														className="p-2 hover:bg-gray-100 rounded-md transition"
+														title="Duplicate (independent copy)"
+													>
+														<Copy className="w-4 h-4 text-[#8757A3]" />
+													</button>
+												</div>
+											</div>
+										))
+									)}
+								</div>
+							)}
 						</div>
 					</div>
 				</div>

--- a/frontend/src/pages/Admin/SurveySummaryPage/DetailedSurveyResponse.tsx
+++ b/frontend/src/pages/Admin/SurveySummaryPage/DetailedSurveyResponse.tsx
@@ -1,286 +1,339 @@
 import React, { useState, useEffect } from "react";
 import apiClient from "../../../services/apiClient";
-import { QuestionType } from "../../../shared/types/question";
-import { X } from "lucide-react";
+import { X, Download, Filter } from "lucide-react";
 import PercentBar from "./PercentBar";
 
 interface DetailedSurveyResponseProps {
-	surveyQuestionIDs: string[];
+	surveyId: string;
+	surveyName: string;
 	toggleModal: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-interface SurveyQuestion {
-	question: string;
-	isMCQ: boolean;
-	numResponses: number;
-	responseOptions: string[];
-	responses: string[];
-	responseBreakdown: number[];
+interface QuestionStat {
+	questionId: string;
+	questionText: string;
+	answerType: string;
+	options: string[];
+	totalAnswered: number;
+	breakdown: Record<string, number>;
 }
 
-interface SurveyResponse {
-	userName: string;
-	userEmail: string;
-	date: Date;
-	answers: string[];
+interface StatGroup {
+	surveyId: string;
+	surveyName: string;
+	surveyVersion: number;
+	courseId: string;
+	courseName: string;
+	totalResponses: number;
+	questions: QuestionStat[];
 }
 
 export default function DetailedSurveyResponse({
-	surveyQuestionIDs,
+	surveyId,
+	surveyName,
 	toggleModal,
 }: DetailedSurveyResponseProps) {
-	const [surveyQuestions, setSurveyQuestions] = useState<SurveyQuestion[]>([]);
-	const [surveyResponses, setSurveyResponses] = useState<SurveyResponse[]>([]);
-
-	const fetchSurveyQuestions = async () => {
-		try {
-			console.log("Fetching survey questions for IDs:", surveyQuestionIDs);
-			const receivedSurveyQuestions: SurveyQuestion[] = [];
-			const receivedResponses: SurveyResponse[] = [];
-
-			// Fetch all questions and their responses
-			for (const surveyQuestionID of surveyQuestionIDs) {
-				console.log("Fetching question:", surveyQuestionID);
-
-				// Handle case where surveyQuestionID might be an object or a string
-				const questionId =
-					typeof surveyQuestionID === "string"
-						? surveyQuestionID
-						: (surveyQuestionID as any)._id;
-				console.log("Using question ID:", questionId);
-
-				// Use query parameter to get specific question since there's no GET /:id route
-				const response = await apiClient.get(`/questions?_id=${questionId}`);
-				const questionsArray = response.data;
-
-				if (!questionsArray || questionsArray.length === 0) {
-					console.warn(`Question with ID ${questionId} not found`);
-					continue; // Skip this question if not found
-				}
-
-				const rawQuestionData: QuestionType = questionsArray[0]; // Get first (and should be only) result
-				console.log("Question data:", rawQuestionData);
-
-				const questionData: SurveyQuestion = {
-					question: rawQuestionData.question,
-					isMCQ: rawQuestionData.isMCQ,
-					responseOptions: rawQuestionData.isMCQ
-						? rawQuestionData.answers || []
-						: [],
-					numResponses: 0,
-					responses: [],
-					responseBreakdown: [],
-				};
-
-				console.log("Fetching question responses for questionId:", questionId);
-				const questionIdResponse = await apiClient.get(
-					`/questionResponses?questionId=${questionId}`
-				);
-				const responses = questionIdResponse.data;
-				console.log("Question responses:", responses);
-
-				// Update question data
-				questionData.numResponses = responses.length;
-				questionData.responses = responses.map(
-					(response: any) => response.answer
-				);
-
-				// Calculate response breakdown for MCQ questions
-				if (questionData.isMCQ) {
-					questionData.responseBreakdown = questionData.responseOptions.map(
-						(option) =>
-							questionData.responses.filter((response) => response === option)
-								.length
-					);
-				}
-
-				receivedSurveyQuestions.push(questionData);
-
-				// Process responses
-				responses.forEach((response: any) => {
-					const existingResponse = receivedResponses.find(
-						(r) => r.userEmail === response.userEmail
-					);
-					if (existingResponse) {
-						existingResponse.answers.push(response.answer);
-					} else {
-						receivedResponses.push({
-							userName: response.userName || "Anonymous",
-							userEmail: response.userEmail,
-							date: new Date(response.createdAt),
-							answers: [response.answer],
-						});
-					}
-				});
-			}
-
-			setSurveyQuestions(receivedSurveyQuestions);
-			setSurveyResponses(receivedResponses);
-		} catch (error) {
-			console.error("Error fetching survey data:", error);
-		}
-	};
-
-	const handleDownloadCSV = () => {
-		if (!surveyQuestions.length || !surveyResponses.length) {
-			console.warn("No survey data available to download");
-			return;
-		}
-
-		// Create headers
-		const headers = [
-			"Submitted",
-			"Name",
-			"Registered User Email",
-			...surveyQuestions.map((q, idx) => `${idx + 1}. ${q.question}`),
-		];
-
-		// Create rows
-		const rows = surveyResponses.map((response) => [
-			response.date.toDateString(),
-			response.userName,
-			response.userEmail,
-			...response.answers,
-		]);
-
-		// Combine headers and rows
-		const csvContent = [
-			headers.join(","),
-			...rows.map((row) => row.map((cell) => `"${cell}"`).join(",")),
-		].join("\n");
-
-		// Create and trigger download
-		const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-		const link = document.createElement("a");
-		const url = URL.createObjectURL(blob);
-		link.setAttribute("href", url);
-		link.setAttribute("download", "survey_responses.csv");
-		document.body.appendChild(link);
-		link.click();
-		document.body.removeChild(link);
-	};
+	const [stats, setStats] = useState<StatGroup[]>([]);
+	const [selectedCourseId, setSelectedCourseId] = useState<string>("all");
+	const [loading, setLoading] = useState(true);
+	const [exportFormat, setExportFormat] = useState<string>("row-per-response");
 
 	useEffect(() => {
-		fetchSurveyQuestions();
-	}, []);
+		fetchStats();
+	}, [surveyId]);
+
+	const fetchStats = async () => {
+		try {
+			setLoading(true);
+			const response = await apiClient.get(
+				`/surveyResponses/stats?surveyId=${surveyId}`
+			);
+			setStats(response.data.data || []);
+		} catch (error) {
+			console.error("Error fetching survey stats:", error);
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	// Aggregate questions across all course groups or filter to one
+	const filteredStats =
+		selectedCourseId === "all"
+			? stats
+			: stats.filter((s) => s.courseId === selectedCourseId);
+
+	// Merge question stats across filtered groups
+	const mergedQuestions: QuestionStat[] = [];
+	let totalResponses = 0;
+	for (const group of filteredStats) {
+		totalResponses += group.totalResponses;
+		for (const q of group.questions) {
+			const existing = mergedQuestions.find(
+				(mq) => mq.questionId === q.questionId
+			);
+			if (existing) {
+				existing.totalAnswered += q.totalAnswered;
+				for (const [key, count] of Object.entries(q.breakdown)) {
+					existing.breakdown[key] = (existing.breakdown[key] || 0) + count;
+				}
+			} else {
+				mergedQuestions.push({
+					...q,
+					breakdown: { ...q.breakdown },
+				});
+			}
+		}
+	}
+
+	// Unique courses for filter dropdown
+	const courseOptions = stats.map((s) => ({
+		id: s.courseId,
+		name: s.courseName,
+	}));
+	const uniqueCourses = courseOptions.filter(
+		(c, i, arr) => arr.findIndex((x) => x.id === c.id) === i
+	);
+
+	const handleExport = async (format: string) => {
+		try {
+			const params = new URLSearchParams({ surveyId, format });
+			if (selectedCourseId !== "all") {
+				params.set("courseId", selectedCourseId);
+			}
+			const response = await apiClient.get(
+				`/surveyResponses/export?${params.toString()}`,
+				{ responseType: "blob" }
+			);
+			const blob = new Blob([response.data], {
+				type: "text/csv;charset=utf-8;",
+			});
+			const link = document.createElement("a");
+			link.href = URL.createObjectURL(blob);
+			link.download = `${surveyName.replace(/\s+/g, "_")}_responses.csv`;
+			document.body.appendChild(link);
+			link.click();
+			document.body.removeChild(link);
+		} catch (error) {
+			console.error("Error exporting:", error);
+		}
+	};
 
 	return (
-		<div className="absolute inset-0 z-50 bg-black/50 flex items-center justify-center">
-			<div className="bg-white flex flex-col w-11/12 h-5/6 shadow-md border rounded-md p-3">
-				<div className="flex w-full justify-between my-2">
-					<h1 className="text-2xl font-bold">Survey Responses</h1>
-					<X
-						className="border rounded-md border-gray-400 mx-2 cursor-pointer"
+		<div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
+			<div className="bg-white flex flex-col w-full max-w-7xl h-[90vh] shadow-xl rounded-xl overflow-hidden">
+				{/* Header */}
+				<div className="flex items-center justify-between px-6 py-4 border-b bg-gray-50">
+					<div>
+						<h1 className="text-xl font-bold text-gray-800">{surveyName}</h1>
+						<p className="text-sm text-gray-500">
+							{totalResponses} total response{totalResponses !== 1 ? "s" : ""}
+						</p>
+					</div>
+					<button
+						className="p-2 hover:bg-gray-200 rounded-lg transition"
 						onClick={() => toggleModal(false)}
-					></X>
+					>
+						<X className="w-5 h-5 text-gray-500" />
+					</button>
 				</div>
 
-				<div className="flex justify-between">
-					<div className="w-4/12 ml-2">
-						<div className="flex justify-end">
-							<button
-								className="text-white text-sm px-6 py-2.5 rounded-lg font-medium hover:opacity-90 w-2/5"
-								style={{ backgroundColor: "#8757a3" }}
-								// onClick={} //TODO: implement download as PDF
-							>
-								Download as PDF
-							</button>
+				{/* Toolbar */}
+				<div className="flex items-center justify-between px-6 py-3 border-b gap-4">
+					<div className="flex items-center gap-3">
+						<Filter className="w-4 h-4 text-gray-400" />
+						<select
+							value={selectedCourseId}
+							onChange={(e) => setSelectedCourseId(e.target.value)}
+							className="border rounded-lg px-3 py-2 text-sm bg-white"
+						>
+							<option value="all">All Courses</option>
+							{uniqueCourses.map((c) => (
+								<option key={c.id} value={c.id}>
+									{c.name}
+								</option>
+							))}
+						</select>
+					</div>
+					<div className="flex items-center gap-2">
+						<select
+							value={exportFormat}
+							onChange={(e) => setExportFormat(e.target.value)}
+							className="border rounded-lg px-3 py-2 text-sm bg-white"
+						>
+							<option value="row-per-response">One row per response</option>
+							<option value="row-per-answer">One row per answer</option>
+						</select>
+						<button
+							className="flex items-center gap-2 text-white text-sm px-4 py-2 rounded-lg font-medium hover:opacity-90 transition"
+							style={{ backgroundColor: "#8757a3" }}
+							onClick={() => handleExport(exportFormat)}
+						>
+							<Download className="w-4 h-4" />
+							Export CSV
+						</button>
+					</div>
+				</div>
+
+				{/* Content */}
+				<div className="flex flex-1 overflow-hidden">
+					{loading ? (
+						<div className="flex items-center justify-center w-full">
+							<p className="text-gray-500">Loading statistics...</p>
 						</div>
-						<h2 className="text-xl font-bold">Questions</h2>
-						<div className="flex flex-col">
-							{surveyQuestions.map((question, index) => (
-								<div key={index} className="flex space-x-2 my-2">
-									<div>{index + 1}</div>
-									<div className="flex flex-col w-full">
-										<div className="font-bold">{question.question}</div>
-										<div className="text-xs text-gray-400">
-											{question.isMCQ ? "Multiple Choice" : "Free Response"}
+					) : mergedQuestions.length === 0 ? (
+						<div className="flex items-center justify-center w-full">
+							<p className="text-gray-500">No responses yet.</p>
+						</div>
+					) : (
+						<>
+							{/* Left Panel - Question Breakdown */}
+							<div className="w-5/12 border-r overflow-y-auto p-6 space-y-6">
+								<h2 className="text-lg font-semibold text-gray-800">
+									Question Breakdown
+								</h2>
+								{mergedQuestions.map((question, index) => (
+									<div
+										key={question.questionId}
+										className="bg-gray-50 rounded-lg p-4 space-y-3"
+									>
+										<div className="flex items-start gap-3">
+											<span className="flex-shrink-0 w-7 h-7 rounded-full bg-[#8757a3] text-white text-sm flex items-center justify-center font-medium">
+												{index + 1}
+											</span>
+											<div className="flex-1">
+												<p className="font-medium text-gray-800">
+													{question.questionText}
+												</p>
+												<p className="text-xs text-gray-400 mt-0.5">
+													{question.answerType} &middot;{" "}
+													{question.totalAnswered} response
+													{question.totalAnswered !== 1 ? "s" : ""}
+												</p>
+											</div>
 										</div>
-										{question.isMCQ ? (
-											<div className="flex flex-col mt-2">
-												{question.responseOptions.map((option, opIdx) => (
-													<div className="text-sm" key={opIdx}>
-														<div>{option}</div>
-														<PercentBar
-															percentage={question.responseBreakdown[opIdx]}
-															total={question.numResponses}
-														></PercentBar>
-													</div>
-												))}
+
+										{question.answerType === "Multiple Choice" ||
+										question.answerType === "Multi-select" ? (
+											<div className="space-y-2 ml-10">
+												{question.options.map((option, opIdx) => {
+													const count = question.breakdown[option] || 0;
+													const pct =
+														question.totalAnswered > 0
+															? Math.round(
+																	(count / question.totalAnswered) * 100
+																)
+															: 0;
+													return (
+														<div key={opIdx}>
+															<div className="text-sm text-gray-700 mb-1">
+																{option}
+															</div>
+															<PercentBar percentage={pct} total={count} />
+														</div>
+													);
+												})}
 											</div>
 										) : (
-											<div className="mt-2">
-												<div className="text-sm">Responses</div>
+											<div className="ml-10">
 												<PercentBar
 													percentage={100}
-													total={question.numResponses}
-												></PercentBar>
+													total={question.totalAnswered}
+												/>
 											</div>
 										)}
 									</div>
-								</div>
-							))}
-						</div>
-					</div>
-
-					<div className="flex flex-col w-7/12 mr-2 overflow-x-auto overflow-y-auto">
-						<div className="flex justify-end space-x-3">
-							<button
-								className="text-white text-sm px-6 py-2.5 rounded-lg font-medium hover:opacity-90"
-								style={{ backgroundColor: "#8757a3" }}
-								onClick={handleDownloadCSV}
-							>
-								Download as CSV
-							</button>
-							<button
-								className="text-white text-sm px-6 py-2.5 rounded-lg font-medium hover:opacity-90"
-								style={{ backgroundColor: "#8757a3" }}
-								// onClick={} //TODO: implement download as PDF
-							>
-								Download as PDF
-							</button>
-						</div>
-						<h2 className="text-xl font-bold">Individual Responses</h2>
-						<table className="border border-gray-300 rounded-lg overflow-hidden mt-3">
-							<thead>
-								<tr className="text-left text-sm align-bottom bg-gray-200">
-									<th className="border border-gray-300 p-2 pb-1">Submitted</th>
-									<th className="border border-gray-300 p-2 pb-1">Name</th>
-									<th className="border border-gray-300 p-2 pb-1">
-										Registered User Email
-									</th>
-									{surveyQuestions.map((question, idx) => (
-										<th key={idx} className="border border-gray-300 p-2 pb-1">
-											{idx + 1}. {question.question}
-										</th>
-									))}
-								</tr>
-							</thead>
-							<tbody className="text-sm">
-								{surveyResponses.map((response, rowIdx) => (
-									<tr
-										key={rowIdx}
-										className={rowIdx % 2 === 0 ? "bg-white" : "bg-gray-200"}
-									>
-										<td className="border border-gray-300 p-2 pb-1">
-											{response.date.toDateString()}
-										</td>
-										<td className="border border-gray-300 p-2 pb-1">
-											{response.userName}
-										</td>
-										<td className="border border-gray-300 p-2 pb-1">
-											{response.userEmail}
-										</td>
-										{response.answers.map((answer) => (
-											<td className="border border-gray-300 p-2 pb-1">
-												{answer}
-											</td>
-										))}
-									</tr>
 								))}
-							</tbody>
-						</table>
-					</div>
+							</div>
+
+							{/* Right Panel - Per-Course Breakdown */}
+							<div className="w-7/12 overflow-y-auto p-6">
+								<h2 className="text-lg font-semibold text-gray-800 mb-4">
+									Responses by Course
+								</h2>
+								{filteredStats.length === 0 ? (
+									<p className="text-gray-500 text-sm">
+										No data for selected filter.
+									</p>
+								) : (
+									<div className="space-y-4">
+										{filteredStats.map((group) => (
+											<div
+												key={`${group.surveyId}-${group.courseId}`}
+												className="bg-gray-50 rounded-lg p-4"
+											>
+												<div className="flex items-center justify-between mb-3">
+													<div>
+														<h3 className="font-medium text-gray-800">
+															{group.courseName}
+														</h3>
+														<p className="text-xs text-gray-400">
+															v{group.surveyVersion} &middot;{" "}
+															{group.totalResponses} response
+															{group.totalResponses !== 1 ? "s" : ""}
+														</p>
+													</div>
+												</div>
+												<div className="overflow-x-auto">
+													<table className="w-full text-sm border-collapse">
+														<thead>
+															<tr className="bg-gray-100">
+																<th className="text-left p-2 border border-gray-200 font-medium text-gray-600">
+																	#
+																</th>
+																<th className="text-left p-2 border border-gray-200 font-medium text-gray-600">
+																	Question
+																</th>
+																<th className="text-center p-2 border border-gray-200 font-medium text-gray-600">
+																	Responses
+																</th>
+																<th className="text-left p-2 border border-gray-200 font-medium text-gray-600">
+																	Top Answer
+																</th>
+															</tr>
+														</thead>
+														<tbody>
+															{group.questions.map((q, idx) => {
+																const topAnswer =
+																	Object.entries(q.breakdown).sort(
+																		([, a], [, b]) => b - a
+																	)[0] || [];
+																return (
+																	<tr
+																		key={q.questionId}
+																		className={
+																			idx % 2 === 0
+																				? "bg-white"
+																				: "bg-gray-50"
+																		}
+																	>
+																		<td className="p-2 border border-gray-200 text-gray-500">
+																			{idx + 1}
+																		</td>
+																		<td className="p-2 border border-gray-200 text-gray-700">
+																			{q.questionText}
+																		</td>
+																		<td className="p-2 border border-gray-200 text-center">
+																			{q.totalAnswered}
+																		</td>
+																		<td className="p-2 border border-gray-200 text-gray-600">
+																			{topAnswer[0] || "—"}
+																			{topAnswer[1]
+																				? ` (${topAnswer[1]})`
+																				: ""}
+																		</td>
+																	</tr>
+																);
+															})}
+														</tbody>
+													</table>
+												</div>
+											</div>
+										))}
+									</div>
+								)}
+							</div>
+						</>
+					)}
 				</div>
 			</div>
 		</div>

--- a/frontend/src/pages/Admin/SurveySummaryPage/SurveySummary.tsx
+++ b/frontend/src/pages/Admin/SurveySummaryPage/SurveySummary.tsx
@@ -1,4 +1,4 @@
-import { Expand, Search } from "lucide-react";
+import { Download, Eye, Search } from "lucide-react";
 import React, { useState, useEffect } from "react";
 import SearchDropdown from "../ComponentPage/DropDownSearch";
 import apiClient from "../../../services/apiClient";
@@ -6,35 +6,33 @@ import { Course } from "../../../shared/types/course";
 import { Pagination } from "../ProductPage/ProductPage";
 import DetailedSurveyResponse from "./DetailedSurveyResponse";
 
-interface SurveyElem {
-	courseTitle: string;
-	numResponses: number;
-	questionIds: string[];
+interface SurveyRow {
+	surveyId: string;
+	surveyName: string;
+	version: number;
+	courses: string[];
+	totalResponses: number;
 }
 
 export default function SurveySummary() {
 	const [searchOptions, setSearchOptions] = useState<string[]>([]);
 	const [searchQuery, setSearchQuery] = useState<string[]>([]);
 	const [currentPage, setCurrentPage] = useState<number>(1);
-	const [itemsPerPage, setItemsPerPage] = useState(15);
-	const [modalOpen, setModalOpen] = useState(false);
+	const [itemsPerPage] = useState(15);
+	const [surveys, setSurveys] = useState<SurveyRow[]>([]);
+	const [loading, setLoading] = useState(true);
 
-	const [surveys, setSurveys] = useState<SurveyElem[]>([]);
-	const displayedSurveys = surveys.filter(
-		(survey) =>
-			searchQuery.length === 0 ||
-			searchQuery.includes(survey.courseTitle.toLowerCase())
-	);
-	const [modalSurveyIds, setModalSurveyIds] = useState<string[]>([]);
+	// Modal state
+	const [modalOpen, setModalOpen] = useState(false);
+	const [modalSurveyId, setModalSurveyId] = useState<string>("");
+	const [modalSurveyName, setModalSurveyName] = useState<string>("");
 
 	const fetchSearchOptions = async () => {
 		try {
 			const response = await apiClient.get("/courses");
-
-			const courseTitles: string[] = response.data.data.map((course: Course) =>
-				course.className.toLowerCase()
+			const courseTitles: string[] = response.data.data.map(
+				(course: Course) => course.className.toLowerCase()
 			);
-
 			setSearchOptions(courseTitles);
 		} catch (error) {
 			console.error(error);
@@ -43,54 +41,46 @@ export default function SurveySummary() {
 
 	const fetchSurveys = async () => {
 		try {
-			console.log("Fetching surveys...");
-			const response = await apiClient.get("/surveys");
-			const survey = response.data;
-			console.log("Survey data:", survey);
+			setLoading(true);
 
-			const receivedSurveys: SurveyElem[] = [];
+			// Fetch all active surveys
+			const surveysResponse = await apiClient.get("/surveys");
+			const allSurveys = surveysResponse.data.data || [];
 
-			// Get all survey responses since they're not tied to a specific survey
-			console.log("Fetching all survey responses...");
-			const surveyResponsesResponse = await apiClient.get("/surveyResponses");
-			console.log("Survey responses data:", surveyResponsesResponse.data);
+			// Fetch stats for all surveys
+			const statsResponse = await apiClient.get("/surveyResponses/stats");
+			const allStats = statsResponse.data.data || [];
 
-			const surveyResponses =
-				surveyResponsesResponse.data.data || surveyResponsesResponse.data;
+			// Build a map of surveyId -> total responses
+			const responseCountMap: Record<string, number> = {};
+			for (const stat of allStats) {
+				const sid = stat.surveyId?.toString() || "";
+				responseCountMap[sid] = (responseCountMap[sid] || 0) + stat.totalResponses;
+			}
 
-			const surveyData: SurveyElem = {
-				courseTitle: "General Survey", // Default title since no course relationship exists
-				numResponses: Array.isArray(surveyResponses)
-					? surveyResponses.length
-					: 0,
-				questionIds: Array.isArray(survey.questions)
-					? survey.questions.map((q: any) => q._id || q)
-					: [],
-			};
-			receivedSurveys.push(surveyData);
+			// Fetch courses for name resolution
+			const coursesResponse = await apiClient.get("/courses");
+			const coursesMap: Record<string, string> = {};
+			for (const course of coursesResponse.data.data || []) {
+				coursesMap[course._id] = course.className;
+			}
 
-			console.log("Final survey data:", receivedSurveys);
-			setSurveys(receivedSurveys);
+			const rows: SurveyRow[] = allSurveys.map((survey: any) => ({
+				surveyId: survey._id,
+				surveyName: survey.name || "Untitled Survey",
+				version: survey.version || 1,
+				courses: (survey.courseIds || []).map(
+					(cid: string) => coursesMap[cid] || "Unknown"
+				),
+				totalResponses: responseCountMap[survey._id] || 0,
+			}));
+
+			setSurveys(rows);
 		} catch (error) {
 			console.error("Error fetching surveys:", error);
+		} finally {
+			setLoading(false);
 		}
-	};
-
-	const tableHeaders = ["Product Title", "Response #", "Responses"];
-	const totalPages: number = Math.ceil(displayedSurveys.length / itemsPerPage);
-
-	const handlePageChange = (page: number) => {
-		if (page >= 1 && page <= totalPages) {
-			setCurrentPage(page);
-		}
-	};
-
-	const handleModalOpen = (surveyIdx: number) => {
-		const selectedSurvey = displayedSurveys[surveyIdx];
-		console.log("Opening modal for survey:", selectedSurvey);
-		console.log("Question IDs:", selectedSurvey.questionIds);
-		setModalSurveyIds(selectedSurvey.questionIds);
-		setModalOpen(true);
 	};
 
 	useEffect(() => {
@@ -98,74 +88,227 @@ export default function SurveySummary() {
 		fetchSurveys();
 	}, []);
 
+	// Filter surveys by course name search
+	const displayedSurveys = surveys.filter(
+		(survey) =>
+			searchQuery.length === 0 ||
+			survey.courses.some((c) =>
+				searchQuery.includes(c.toLowerCase())
+			)
+	);
+
+	const totalPages = Math.ceil(displayedSurveys.length / itemsPerPage);
+	const paginatedSurveys = displayedSurveys.slice(
+		(currentPage - 1) * itemsPerPage,
+		currentPage * itemsPerPage
+	);
+
+	const handlePageChange = (page: number) => {
+		if (page >= 1 && page <= totalPages) {
+			setCurrentPage(page);
+		}
+	};
+
+	const handleViewDetails = (survey: SurveyRow) => {
+		setModalSurveyId(survey.surveyId);
+		setModalSurveyName(survey.surveyName);
+		setModalOpen(true);
+	};
+
+	const handleExportAll = async () => {
+		try {
+			const response = await apiClient.get(
+				"/surveyResponses/export?format=row-per-response",
+				{ responseType: "blob" }
+			);
+			const blob = new Blob([response.data], {
+				type: "text/csv;charset=utf-8;",
+			});
+			const link = document.createElement("a");
+			link.href = URL.createObjectURL(blob);
+			link.download = "all_survey_responses.csv";
+			document.body.appendChild(link);
+			link.click();
+			document.body.removeChild(link);
+		} catch (error) {
+			console.error("Error exporting all:", error);
+		}
+	};
+
+	const handleExportSingle = async (surveyId: string, surveyName: string) => {
+		try {
+			const response = await apiClient.get(
+				`/surveyResponses/export?surveyId=${surveyId}&format=row-per-response`,
+				{ responseType: "blob" }
+			);
+			const blob = new Blob([response.data], {
+				type: "text/csv;charset=utf-8;",
+			});
+			const link = document.createElement("a");
+			link.href = URL.createObjectURL(blob);
+			link.download = `${surveyName.replace(/\s+/g, "_")}_responses.csv`;
+			document.body.appendChild(link);
+			link.click();
+			document.body.removeChild(link);
+		} catch (error) {
+			console.error("Error exporting:", error);
+		}
+	};
+
 	return (
 		<div className="w-full min-h-screen bg-gray-100">
 			{modalOpen && (
 				<DetailedSurveyResponse
-					surveyQuestionIDs={modalSurveyIds}
+					surveyId={modalSurveyId}
+					surveyName={modalSurveyName}
 					toggleModal={setModalOpen}
-				></DetailedSurveyResponse>
+				/>
 			)}
 
 			<div className="max-w-screen-2xl mx-auto px-8 py-6 space-y-4">
-				<div className="bg-white border rounded-lg p-6">
-					<div className="flex justify-between">
-						<div className="mb-6">
-							<h1 className="text-2xl font-bold">Survey Results</h1>
+				<div className="bg-white border rounded-xl shadow-sm p-6">
+					{/* Header */}
+					<div className="flex items-center justify-between mb-6">
+						<div>
+							<h1 className="text-2xl font-bold text-gray-800">
+								Survey Results
+							</h1>
+							<p className="text-sm text-gray-500 mt-1">
+								{surveys.length} survey{surveys.length !== 1 ? "s" : ""} &middot;{" "}
+								{surveys.reduce((sum, s) => sum + s.totalResponses, 0)} total
+								responses
+							</p>
 						</div>
-						<Expand className="w-6 border rounded-lg p-1 cursor-pointer"></Expand>
+						<button
+							onClick={handleExportAll}
+							className="flex items-center gap-2 text-white text-sm px-5 py-2.5 rounded-lg font-medium hover:opacity-90 transition"
+							style={{ backgroundColor: "#8757a3" }}
+						>
+							<Download className="w-4 h-4" />
+							Export All
+						</button>
 					</div>
 
+					{/* Search */}
 					<SearchDropdown
 						options={searchOptions}
 						selected={searchQuery}
 						setSelected={setSearchQuery}
-						placeholder="Search"
-					></SearchDropdown>
+						placeholder="Filter by course name..."
+					/>
 
-					<table className="w-full border border-gray-300 rounded-md border-separate border-spacing-0 text-sm mt-5">
-						<thead className="bg-gray-100 rounded-md">
-							<tr>
-								{tableHeaders.map((header, idx) => (
-									<th
-										key={idx}
-										className="border border-gray-200 first:rounded-tl-md last:rounded-tr-md text-left pl-3"
-									>
-										{header}
-									</th>
-								))}
-							</tr>
-						</thead>
-						<tbody>
-							{displayedSurveys.map((survey, rowIdx) => (
-								<tr
-									key={rowIdx}
-									className={rowIdx % 2 === 0 ? "bg-white" : "bg-gray-100"}
-								>
-									<td className="border border-gray-200 text-left w-9/12 pl-3">
-										{survey.courseTitle}
-									</td>
-									<td className="border border-gray-200 w-2/12 text-center">
-										{survey.numResponses}
-									</td>
-									<td className="border border-gray-200 w-1/12 text-center">
-										<Search
-											className="w-6 border rounded-lg p-1 cursor-pointer"
-											onClick={() => handleModalOpen(rowIdx)}
-										></Search>
-									</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
+					{/* Table */}
+					{loading ? (
+						<div className="flex justify-center py-12">
+							<p className="text-gray-500">Loading surveys...</p>
+						</div>
+					) : displayedSurveys.length === 0 ? (
+						<div className="flex justify-center py-12">
+							<p className="text-gray-500">No surveys found.</p>
+						</div>
+					) : (
+						<div className="overflow-hidden rounded-lg border border-gray-200 mt-4">
+							<table className="w-full text-sm">
+								<thead>
+									<tr className="bg-gray-50 text-left text-gray-600">
+										<th className="px-4 py-3 font-medium">Survey Name</th>
+										<th className="px-4 py-3 font-medium">
+											Associated Courses
+										</th>
+										<th className="px-4 py-3 font-medium text-center">
+											Version
+										</th>
+										<th className="px-4 py-3 font-medium text-center">
+											Responses
+										</th>
+										<th className="px-4 py-3 font-medium text-center">
+											Actions
+										</th>
+									</tr>
+								</thead>
+								<tbody className="divide-y divide-gray-100">
+									{paginatedSurveys.map((survey, rowIdx) => (
+										<tr
+											key={survey.surveyId}
+											className={`hover:bg-gray-50 transition ${
+												rowIdx % 2 === 0 ? "bg-white" : "bg-gray-50/50"
+											}`}
+										>
+											<td className="px-4 py-3 font-medium text-gray-800">
+												{survey.surveyName}
+											</td>
+											<td className="px-4 py-3">
+												<div className="flex flex-wrap gap-1">
+													{survey.courses.length > 0 ? (
+														survey.courses.map((course, idx) => (
+															<span
+																key={idx}
+																className="inline-block bg-purple-50 text-purple-700 text-xs px-2 py-0.5 rounded-full"
+															>
+																{course}
+															</span>
+														))
+													) : (
+														<span className="text-gray-400 text-xs">
+															No courses
+														</span>
+													)}
+												</div>
+											</td>
+											<td className="px-4 py-3 text-center text-gray-500">
+												v{survey.version}
+											</td>
+											<td className="px-4 py-3 text-center">
+												<span
+													className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-medium ${
+														survey.totalResponses > 0
+															? "bg-green-50 text-green-700"
+															: "bg-gray-100 text-gray-500"
+													}`}
+												>
+													{survey.totalResponses}
+												</span>
+											</td>
+											<td className="px-4 py-3">
+												<div className="flex items-center justify-center gap-2">
+													<button
+														onClick={() => handleViewDetails(survey)}
+														className="p-1.5 hover:bg-gray-100 rounded-md transition"
+														title="View details"
+													>
+														<Eye className="w-4 h-4 text-gray-500" />
+													</button>
+													<button
+														onClick={() =>
+															handleExportSingle(
+																survey.surveyId,
+																survey.surveyName
+															)
+														}
+														className="p-1.5 hover:bg-gray-100 rounded-md transition"
+														title="Export CSV"
+													>
+														<Download className="w-4 h-4 text-gray-500" />
+													</button>
+												</div>
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					)}
 
-					<div className="flex justify-end mt-6">
-						<Pagination
-							currentPage={currentPage}
-							totalPages={totalPages || 1}
-							onPageChange={handlePageChange}
-						/>
-					</div>
+					{/* Pagination */}
+					{totalPages > 1 && (
+						<div className="flex justify-end mt-6">
+							<Pagination
+								currentPage={currentPage}
+								totalPages={totalPages}
+								onPageChange={handlePageChange}
+							/>
+						</div>
+					)}
 				</div>
 			</div>
 		</div>

--- a/frontend/src/pages/courseDetailPage/SurveyModal.tsx
+++ b/frontend/src/pages/courseDetailPage/SurveyModal.tsx
@@ -6,6 +6,7 @@ interface SurveyModalProps {
 	isOpen: boolean;
 	onClose: any;
 	courseId: string | null;
+	surveyId: string | null;
 	setSurveyCompleted: any;
 }
 
@@ -13,6 +14,7 @@ export default function SurveyModal({
 	isOpen,
 	onClose,
 	courseId,
+	surveyId,
 	setSurveyCompleted,
 }: SurveyModalProps) {
 	const [questionNumber, setQuestionNumber] = useState<number>(0);
@@ -20,33 +22,22 @@ export default function SurveyModal({
 	const [responses, setResponses] = useState<{ [key: string]: string }>({});
 
 	useEffect(() => {
+		if (!surveyId) return;
+
 		const populateQuestions = async () => {
-			let tempQuestions: any[] = [];
 			try {
-				const questionIds = (await apiClient.get("surveys")).data.questions;
-				console.log(questionIds);
-				setSurveyQuestions(questionIds);
+				const response = await apiClient.get(`surveys/${surveyId}`);
+				const survey = response.data.survey || response.data;
+				setSurveyQuestions(survey.questions || []);
 			} catch (error) {
-				console.error("Error: ", error);
+				console.error("Error fetching survey:", error);
 			}
 		};
 
 		populateQuestions();
-	}, []);
+	}, [surveyId]);
 
 	if (!isOpen) return null;
-
-	// async function addQuestion() {
-	// 	try {
-	// 		const response = await apiClient.post("survey", {
-	// 			question: "Do you have any other feedback for the course?",
-	// 			isMCQ: false,
-	// 		});
-	// 		console.log(response.status);
-	// 	} catch (error) {
-	// 		console.error("Failed to check admin status", error);
-	// 	}
-	// }
 
 	const handleAnswerChange = (questionId: string, answer: string) => {
 		setResponses((prev) => ({
@@ -60,32 +51,36 @@ export default function SurveyModal({
 			setQuestionNumber(questionNumber + 1);
 		} else {
 			try {
+				const userId = JSON.parse(localStorage.user)._id;
+
+				// Create question responses
 				let responseIds = [];
 				for (let id of Object.keys(responses)) {
 					const response = await apiClient.post("questionResponses", {
-						userId: JSON.parse(localStorage.user)._id,
+						userId,
 						questionId: id,
 						answer: responses[`${id}`].toString(),
 					});
 					responseIds.push(response.data._id);
 				}
-				const response = await apiClient.post("surveyResponses", {
-					userId: JSON.parse(localStorage.user)._id,
+
+				// Create survey response with surveyId and courseId
+				await apiClient.post("surveyResponses", {
+					userId,
 					answers: responseIds,
+					surveyId,
+					courseId,
 				});
 
-				// let surveyResponseId = response.data._id
-				// Beloved EM please add the updating the course to append the survey response once the other changes from Kevin is added for this.
-
-				const progressResponse = await apiClient.put(
-					`/courses/${courseId}/progress/single/${JSON.parse(localStorage.user)._id}`,
+				// Update progress
+				await apiClient.put(
+					`/courses/${courseId}/progress/single/${userId}`,
 					{
 						surveyComplete: true,
 						webinarComplete: true,
 					}
 				);
 				setSurveyCompleted(true);
-				console.log("progress updated");
 			} catch (error) {
 				console.error(error);
 			}
@@ -113,7 +108,7 @@ export default function SurveyModal({
 					className="absolute top-4 right-4 text-gray-500 hover:text-gray-700 text-2xl font-bold"
 					aria-label="Close"
 				>
-					×
+					&times;
 				</button>
 				<h2 className="text-2xl font-bold mb-6 text-center">Survey</h2>
 				<div className="flex-1 overflow-auto">

--- a/frontend/src/pages/courseDetailPage/courseDetailsPage.tsx
+++ b/frontend/src/pages/courseDetailPage/courseDetailsPage.tsx
@@ -387,6 +387,7 @@ const CoursePage = ({ setCartItemCount }: CatalogProps) => {
 								setCertificateCompleted={setCertificateCompleted}
 								courseName={courseDetailsData.className}
 								certificate={certificateCompleted}
+								surveyId={courseDetailsData.surveyId || null}
 							/>
 						</div>
 					</div>
@@ -487,6 +488,7 @@ const DisplayBar = ({
 	certificate,
 	courseName,
 	creditHours,
+	surveyId,
 }: {
 	creditHours: number;
 	time: Date;
@@ -502,6 +504,7 @@ const DisplayBar = ({
 	setSurveyCompleted: any;
 	setCertificateCompleted: any;
 	courseName: string;
+	surveyId: string | null;
 }) => {
 	const [currentPage, setCurrentPage] = useState("Workshop");
 	const [surveyColor, setSurveyColor] = useState("#D9D9D9");
@@ -903,23 +906,32 @@ const DisplayBar = ({
 					{currentPage === "Survey" && (
 						<div className="text-sm font-normal flex flex-col gap-3">
 							<div className="flex flex-col text-xs">
-								<p
-									className={workshop ? "hidden text-red-600" : "text-red-600"}
-								>
-									Complete workshop to access survey. (For in person events,
-									this may take a couple of days to update.)
-								</p>
-								<button
-									className={`w-max rounded-md text-center text-white text-xs align-middle px-6 py-3 bg-orange-400 disabled:bg-gray-400 disabled:cursor-not-allowed bg-[#F79518]}`}
-									disabled={!workshop || survey}
-									onClick={() => setIsSurveyModalOpen(true)}
-								>
-									{survey ? "Already Completed Survey" : "Begin Survey"}
-								</button>
+								{!surveyId ? (
+									<p className="text-gray-500">
+										No survey configured for this course.
+									</p>
+								) : (
+									<>
+										<p
+											className={workshop ? "hidden text-red-600" : "text-red-600"}
+										>
+											Complete workshop to access survey. (For in person events,
+											this may take a couple of days to update.)
+										</p>
+										<button
+											className={`w-max rounded-md text-center text-white text-xs align-middle px-6 py-3 bg-orange-400 disabled:bg-gray-400 disabled:cursor-not-allowed bg-[#F79518]}`}
+											disabled={!workshop || survey}
+											onClick={() => setIsSurveyModalOpen(true)}
+										>
+											{survey ? "Already Completed Survey" : "Begin Survey"}
+										</button>
+									</>
+								)}
 								<SurveyModal
 									isOpen={isSurveyModalOpen}
 									onClose={() => setIsSurveyModalOpen(false)}
 									courseId={courseId}
+									surveyId={surveyId || null}
 									setSurveyCompleted={setSurveyCompleted}
 								></SurveyModal>
 							</div>

--- a/frontend/src/shared/types/course.tsx
+++ b/frontend/src/shared/types/course.tsx
@@ -36,4 +36,5 @@ export type Course = {
 	shortUrl: string;
 	draft: boolean;
 	registrationLimit: number;
+	surveyId?: string;
 };

--- a/frontend/src/shared/types/question.tsx
+++ b/frontend/src/shared/types/question.tsx
@@ -1,8 +1,10 @@
 export type QuestionType = {
 	id: string;
 	question: string;
-	isMCQ: boolean;
-	answers?: string[]; // Optional array of possible answers
+	explanation?: string;
+	answerType: "Text Input" | "Multiple Choice" | "Multi-select";
+	answers?: string[];
+	isRequired: boolean;
 	createdAt?: Date;
 	updatedAt?: Date;
 };

--- a/frontend/src/shared/types/survey.tsx
+++ b/frontend/src/shared/types/survey.tsx
@@ -1,7 +1,13 @@
 import { QuestionType } from "./question";
+
 export type SurveyType = {
 	id: string;
-	questions: QuestionType[]; // Array of QuestionType objects
+	name: string;
+	questions: QuestionType[];
+	courseIds: string[];
+	version: number;
+	parentSurveyId?: string;
+	isActive: boolean;
 	createdAt?: Date;
 	updatedAt?: Date;
 };

--- a/frontend/src/store/useCourseEditStore.ts
+++ b/frontend/src/store/useCourseEditStore.ts
@@ -30,6 +30,7 @@ interface CourseEditState {
 	shortUrl?: string;
 	draft: boolean;
 	registrationLimit: number;
+	surveyId?: string;
 
 	// Hydration & data control
 	hasHydrated: boolean;
@@ -82,6 +83,7 @@ const initialState: Omit<
 	shortUrl: undefined,
 	draft: true,
 	registrationLimit: 0,
+	surveyId: undefined,
 };
 
 export const useCourseEditStore = create<CourseEditState>()(


### PR DESCRIPTION
Replaces the single global survey with a full per-course survey system. Previously, editing the survey overwrote it for all courses, responses weren't linked to specific courses or survey versions, and the admin stats page only showed one row (?)

Now:
- Each course can have its own survey, assigned via `course.surveyId` ↔ `survey.courseIds[]`
- Editing a survey that already has responses creates a new version (copy-on-write), preserving historical data. Admins choose which courses receive the update.
- Admins can share an existing survey across courses (same object) or duplicate it as an independent copy
- Stats page now shows all surveys in a filterable table with per-course breakdowns, question-level answer distributions, and server-side CSV export (row-per-response or row-per-answer format)
- `backend/scripts/migrateSurveys.ts` backfills existing data; links all courses to the existing survey and tags orphaned responses with `surveyId`